### PR TITLE
Adressverwaltung allow below admin

### DIFF
--- a/app/models/group/pfadi.rb
+++ b/app/models/group/pfadi.rb
@@ -51,7 +51,7 @@ class Group::Pfadi < Group
   end
 
   class Adressverwaltung < ::Role
-    self.permissions = [:group_full]
+    self.permissions = [:layer_and_below_full]
   end
 
   class Leitpfadi < ::Role


### PR DESCRIPTION
Allow "Adressverwaltung" of one Pfadi's group to manage the children of this group: Pfadi and Gremium.
Actualy, if a "Adressverwaltung" created a sub-group (Pfadi or Gremium) he can not manage it unless he added himself as admistrateur of this child-group. 
Same modification as to be done for woelfe.rb, pio.rb, and for biber.rb 