### PR TITLE
add age overview for abteilung, crude version

### DIFF
--- a/app/controllers/population_controller.rb
+++ b/app/controllers/population_controller.rb
@@ -19,7 +19,7 @@ class PopulationController < ApplicationController
     @people_by_group = load_people_by_group
     @people_data_complete = people_data_complete?
     @total = @member_counter.count
-    @years = @member_counter.members_per_year
+    @years = @member_counter.members_per_birthyear
   end
 
   private

--- a/app/controllers/population_controller.rb
+++ b/app/controllers/population_controller.rb
@@ -19,7 +19,7 @@ class PopulationController < ApplicationController
     @people_by_group = load_people_by_group
     @people_data_complete = people_data_complete?
     @total = @member_counter.count
-    @years = @member_counter.members_per_birthyear
+    @members_per_birthyear = @member_counter.members_per_birthyear
   end
 
   private

--- a/app/controllers/population_controller.rb
+++ b/app/controllers/population_controller.rb
@@ -19,6 +19,7 @@ class PopulationController < ApplicationController
     @people_by_group = load_people_by_group
     @people_data_complete = people_data_complete?
     @total = @member_counter.count
+    @years = @member_counter.members_per_year
   end
 
   private

--- a/app/domain/member_counter.rb
+++ b/app/domain/member_counter.rb
@@ -86,7 +86,10 @@ class MemberCounter
     count
   end
 
-  def members_per_year
+  # Gives back a population birthyear/age histogram. Each birthyear between
+  # the ones of the youngest and oldest active members of the organization
+  # is evaluated.
+  def members_per_birthyear
     years = members.pluck(:birthday).map{|b| b.try :year}
     year_counts = years.inject(Hash.new(0)) do |total, e|
       total[e] +=1

--- a/app/domain/member_counter.rb
+++ b/app/domain/member_counter.rb
@@ -86,6 +86,19 @@ class MemberCounter
     count
   end
 
+  def members_per_year
+    years = members.pluck(:birthday).map{|b| b.try :year}
+    year_counts = years.inject(Hash.new(0)) do |total, e|
+      total[e] +=1
+      total
+    end
+    maxcount = year_counts.values.max
+    oldest, latest = years.select{|y| !y.nil?}.minmax
+    (oldest..latest).map do |year|
+      [year, year_counts[year].to_f / maxcount, year_counts[year]]
+    end + [[nil, year_counts[nil].to_f / maxcount, year_counts[nil]]]
+  end
+
   def exists?
     MemberCount.where(abteilung_id: abteilung.id, year: year).exists?
   end

--- a/app/domain/member_counter.rb
+++ b/app/domain/member_counter.rb
@@ -91,10 +91,9 @@ class MemberCounter
   # is evaluated.
   def members_per_birthyear
     # pluck :birthday breaks the function because distinct is used in the query
-    years = members.map(&:birthday).map{|b| b.try :year}
-    year_counts = years.inject(Hash.new(0)) do |total, e|
-      total[e] +=1
-      total
+    years = members.map(&:birthday).map { |b| b.try :year }
+    year_counts = years.each_with_object(Hash.new(0)) do |year, total|
+      total[year] += 1
     end
     add_relative_count complete_year_histogram(year_counts)
   end
@@ -125,7 +124,7 @@ class MemberCounter
   # in the members list
   def complete_year_histogram(year_counts)
     return [] if year_counts.empty?
-    oldest, latest = year_counts.keys.select{|y| !y.nil?}.minmax
+    oldest, latest = year_counts.keys.select { |y| !y.nil? }.minmax
     return nil_year_if_necessary(year_counts) if oldest.nil?
     (latest).downto(oldest).map do |year|
       OpenStruct.new(year: year, count: year_counts[year])

--- a/app/domain/member_counter.rb
+++ b/app/domain/member_counter.rb
@@ -96,7 +96,7 @@ class MemberCounter
       total[e] +=1
       total
     end
-    complete_year_histogram year_counts
+    add_relative_count complete_year_histogram(year_counts)
   end
 
   def exists?
@@ -124,30 +124,25 @@ class MemberCounter
   # completes the histogram by also considering years which don't appear
   # in the members list
   def complete_year_histogram(year_counts)
-    if year_counts.count == 0
-      return []
-    end
-    if (year_counts.keys - [nil]).count == 0
-      return nil_year_if_necessary(year_counts, year_counts.values[0])
-    end
-    maxcount = year_counts.values.max
+    return [] if year_counts.empty?
     oldest, latest = year_counts.keys.select{|y| !y.nil?}.minmax
+    return nil_year_if_necessary(year_counts) if oldest.nil?
     (latest).downto(oldest).map do |year|
-      OpenStruct.new(
-        year: year,
-        count: year_counts[year],
-        count_relative: year_counts[year].to_f / maxcount
-      )
-    end + nil_year_if_necessary(year_counts, maxcount)
+      OpenStruct.new(year: year, count: year_counts[year])
+    end + nil_year_if_necessary(year_counts)
   end
 
-  def nil_year_if_necessary(year_counts, maxcount)
+  def nil_year_if_necessary(year_counts)
     return [] if year_counts[nil] == 0
-    [OpenStruct.new(
-      year: nil,
-      count: year_counts[nil],
-      count_relative: year_counts[nil].to_f / maxcount
-    )]
+    [OpenStruct.new(year: nil, count: year_counts[nil])]
+  end
+
+  def add_relative_count(year_histogram)
+    maxcount = year_histogram.map(&:count).max
+    year_histogram.each do |y|
+      y.count_relative = y.count.to_f / maxcount
+    end
+    year_histogram
   end
 
   def new_member_count

--- a/app/helpers/population_helper.rb
+++ b/app/helpers/population_helper.rb
@@ -29,7 +29,7 @@ module PopulationHelper
 
   def age(year)
     return '-' if year.nil?
-    age = DateTime.now.year - year
+    age = Time.zone.now.year - year
     if age < 0
       '-'
     else

--- a/app/helpers/population_helper.rb
+++ b/app/helpers/population_helper.rb
@@ -27,4 +27,14 @@ module PopulationHelper
     group.population_approveable? && can?(:create_member_counts, group)
   end
 
+  def age(year)
+    return '-' if year.nil?
+    age = DateTime.now.year - year
+    if age < 0
+      '-'
+    else
+      age
+    end
+  end
+
 end

--- a/app/views/population/_birthyears_overview.html.haml
+++ b/app/views/population/_birthyears_overview.html.haml
@@ -1,0 +1,23 @@
+-#  Copyright (c) 2012-2014, Pfadibewegung Schweiz. This file is part of
+-#  hitobito_pbs and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_pbs.
+
+%h2= t('population.index.birthyears_overview')
+
+%table.table.table-striped.table-hover
+  %thead
+    %tr
+      %th= t('population.index.year')
+      %th= t('population.index.age')
+      %th{colspan: 2}= t('population.index.count')
+  %tbody
+    - @years.each do |year, count_rel, count|
+      %tr
+        %td
+          %strong= year || t('population.index.no_birthday_given')
+        %td= age(year)
+        %td= count
+        %td{style: 'width: 100%'}
+          %div{style: "background: #9ec6c6; width: #{(count_rel * 97).to_i}%"}
+            &nbsp;

--- a/app/views/population/_birthyears_overview.html.haml
+++ b/app/views/population/_birthyears_overview.html.haml
@@ -12,12 +12,12 @@
       %th= t('population.index.age')
       %th{colspan: 2}= t('population.index.count')
   %tbody
-    - @years.each do |year, count_rel, count|
+    - @years.each do |y|
       %tr
         %td
-          %strong= year || t('population.index.no_birthday_given')
-        %td= age(year)
-        %td= count
+          %strong= y.year || t('population.index.no_birthday_given')
+        %td= age(y.year)
+        %td{style: 'padding-right: 1em;'}= y.count
         %td{style: 'width: 100%'}
-          %div{style: "background: #9ec6c6; width: #{(count_rel * 97).to_i}%"}
+          %div{style: "background: #9ec6c6; width: #{(y.count_relative * 98).to_i}%"}
             &nbsp;

--- a/app/views/population/_birthyears_overview.html.haml
+++ b/app/views/population/_birthyears_overview.html.haml
@@ -12,7 +12,7 @@
       %th= t('population.index.age')
       %th{colspan: 2}= t('population.index.count')
   %tbody
-    - @years.each do |y|
+    - @members_per_birthyear.each do |y|
       %tr
         %td
           %strong= y.year || t('population.index.no_birthday_given')

--- a/app/views/population/index.html.haml
+++ b/app/views/population/index.html.haml
@@ -13,7 +13,7 @@
 %h2= t('.current_census_data')
 = render 'census_evaluation/abteilung/totals'
 
-- unless @years.empty?
+- unless @members_per_birthyear.empty?
   = render 'birthyears_overview'
 
 = render 'people_list'

--- a/app/views/population/index.html.haml
+++ b/app/views/population/index.html.haml
@@ -13,7 +13,8 @@
 %h2= t('.current_census_data')
 = render 'census_evaluation/abteilung/totals'
 
-= render 'birthyears_overview'
+- unless @years.empty?
+  = render 'birthyears_overview'
 
 = render 'people_list'
 

--- a/app/views/population/index.html.haml
+++ b/app/views/population/index.html.haml
@@ -10,12 +10,12 @@
   - else
     = t('.no_census_data_requested')
 
-
 %h2= t('.current_census_data')
 = render 'census_evaluation/abteilung/totals'
 
-= render 'people_list'
+= render 'birthyears_overview'
 
+= render 'people_list'
 
 - if check_approveable?
   - if @people_data_complete

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -104,6 +104,11 @@ de:
     index:
       confirm_census_data: Bestand bestätigen
       current_census_data: Aktueller Bestand
+      birthyears_overview: Jahrgangsübersicht
+      count: Anzahl
+      age: Alter
+      year: Jahrgang
+      no_birthday_given: Kein Jahrgang angegeben
       no_census_data_requested: Momentan ist keine Bestandesmeldung ausstehend.
       please_confirm_census_data: 'Bitte ergänze das Geschlecht aller Mitglieder und bestätige den Bestand deiner Abteilung mit "Bestand bestätigen".'
       missing_gender_information: Um den Bestand bestätigen zu können, muss bei allen Mitgliedern das Geschlecht ausgefüllt sein.

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -108,7 +108,7 @@ de:
       count: Anzahl
       age: Alter
       year: Jahrgang
-      no_birthday_given: Kein Jahrgang angegeben
+      no_birthday_given: Unbekannt
       no_census_data_requested: Momentan ist keine Bestandesmeldung ausstehend.
       please_confirm_census_data: 'Bitte ergänze das Geschlecht aller Mitglieder und bestätige den Bestand deiner Abteilung mit "Bestand bestätigen".'
       missing_gender_information: Um den Bestand bestätigen zu können, muss bei allen Mitgliedern das Geschlecht ausgefüllt sein.

--- a/config/locales/views.pbs.fr.yml
+++ b/config/locales/views.pbs.fr.yml
@@ -90,7 +90,7 @@ fr:
       count: Nombre
       age: Âge
       year: Année
-      no_birthday_given: Année n'est pas disponible
+      no_birthday_given: Inconnu
       no_census_data_requested: Il n'y a pas de déclaration des effectifs ouverte en ce moment.
       please_confirm_census_data: 'S''il-te-plaît, indique le sexe de tous les membres et confirme les effectifs de ton groupe en cliquant sur "confirmer les effectifs".'
       missing_gender_information: Le sexe de tous les membres doit être indiqué avant de pouvoir confirmer les effectifs.

--- a/config/locales/views.pbs.fr.yml
+++ b/config/locales/views.pbs.fr.yml
@@ -86,6 +86,11 @@ fr:
     index:
       confirm_census_data: Confirmer les effectifs
       current_census_data: Effectifs actuels
+      birthyears_overview: Exposé des années
+      count: Nombre
+      age: Âge
+      year: Année
+      no_birthday_given: Année n'est pas disponible
       no_census_data_requested: Il n'y a pas de déclaration des effectifs ouverte en ce moment.
       please_confirm_census_data: 'S''il-te-plaît, indique le sexe de tous les membres et confirme les effectifs de ton groupe en cliquant sur "confirmer les effectifs".'
       missing_gender_information: Le sexe de tous les membres doit être indiqué avant de pouvoir confirmer les effectifs.

--- a/config/locales/views.pbs.it.yml
+++ b/config/locales/views.pbs.it.yml
@@ -86,6 +86,11 @@ it:
     index:
       confirm_census_data: Confermare i censimenti
       current_census_data: Censimenti attuali
+      birthyears_overview: Annata
+      count: Numero
+      age: Età
+      year: Annata
+      no_birthday_given: Nessuna disponibile
       no_census_data_requested: Al momento non c'è nessun censimento ancora in sospeso.
       please_confirm_census_data: 'Per favore completare il sesso di tutti i membri e confermare i censimenti della tua sezione con "Confermare i censimenti"'
       missing_gender_information: Per poter inviare i censimenti, a tutti i membri deve essere assegnato il sesso.

--- a/config/locales/views.pbs.it.yml
+++ b/config/locales/views.pbs.it.yml
@@ -90,7 +90,7 @@ it:
       count: Numero
       age: Età
       year: Annata
-      no_birthday_given: Nessuna disponibile
+      no_birthday_given: Incognita
       no_census_data_requested: Al momento non c'è nessun censimento ancora in sospeso.
       please_confirm_census_data: 'Per favore completare il sesso di tutti i membri e confermare i censimenti della tua sezione con "Confermare i censimenti"'
       missing_gender_information: Per poter inviare i censimenti, a tutti i membri deve essere assegnato il sesso.

--- a/spec/controllers/population_controller_spec.rb
+++ b/spec/controllers/population_controller_spec.rb
@@ -59,6 +59,12 @@ describe PopulationController do
 
       it { is_expected.to be_falsey }
     end
+
+    describe 'shows year data' do
+      subject { assigns(:years) }
+
+      it { expect(subject.map(&:count).sum).to eq(assigns(:total).total) }
+    end
   end
 
   describe 'GET index does not include deleted groups' do

--- a/spec/controllers/population_controller_spec.rb
+++ b/spec/controllers/population_controller_spec.rb
@@ -61,7 +61,7 @@ describe PopulationController do
     end
 
     describe 'shows year data' do
-      subject { assigns(:years) }
+      subject { assigns(:members_per_birthyear) }
 
       it { expect(subject.map(&:count).sum).to eq(assigns(:total).total) }
     end

--- a/spec/domain/member_counter_spec.rb
+++ b/spec/domain/member_counter_spec.rb
@@ -105,4 +105,42 @@ describe MemberCounter do
     end
   end
 
+  context 'members_per_birthyear' do
+
+    subject { MemberCounter.new(2011, abteilung).members_per_birthyear }
+
+    it 'counts all active members' do
+      expect(subject.map(&:count).sum).to eq(9)
+    end
+
+    it 'counts correct amount of members per year' do
+      expect(subject.select{|y| y.year == 1999}[0].count).to eq(3)
+      expect(subject.select{|y| y.year == 1988}[0].count).to eq(1)
+    end
+
+    it 'counts nil birthdays' do
+      expect(subject.select{|y| y.year.nil?}[0].count).to eq(2)
+    end
+
+    it 'works with only nil birthdays' do
+      Person.where('birthday IS NOT NULL').delete_all
+      expect(subject[0].count).to eq(2)
+    end
+
+    it 'works if no people present' do
+      Person.delete_all
+      expect(subject).to be_empty
+    end
+
+    it 'doesn\'t show counted nils if there are none' do
+      Person.where('birthday IS NULL').delete_all
+      expect(subject.select{|y| y.year.nil?}).to be_empty
+    end
+
+    it 'gives count relative to maximum count' do
+      expect(subject.select{|y| y.year == 1999}[0].count_relative).to eq(1)
+      expect(subject.select{|y| y.year == 1988}[0].count_relative).to eq(1.0/3)
+    end
+  end
+
 end

--- a/spec/helpers/population_helper_spec.rb
+++ b/spec/helpers/population_helper_spec.rb
@@ -12,7 +12,7 @@ describe PopulationHelper do
   context '#age' do
 
     before do
-      allow(DateTime).to receive(:now).and_return(DateTime.new(2014, 6, 10))
+      allow(Time).to receive_message_chain(:zone, :now).and_return(DateTime.new(2014, 6, 10))
     end
 
     it 'accepts nil' do

--- a/spec/helpers/population_helper_spec.rb
+++ b/spec/helpers/population_helper_spec.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2014, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe PopulationHelper do
+
+  context '#age' do
+
+    before do
+      allow(DateTime).to receive(:now).and_return(DateTime.new(2014, 6, 10))
+    end
+
+    it 'accepts nil' do
+      expect(helper.age(nil)).to eq('-')
+    end
+
+    it 'accepts future birthyear' do
+      expect(helper.age(2016)).to eq('-')
+    end
+
+    it 'calculates correct age #1' do
+      expect(helper.age(2014)).to eq(0)
+    end
+
+    it 'calculates correct age #2' do
+      expect(helper.age(2000)).to eq(14)
+    end
+  end
+
+end

--- a/spec/regressions/population_controller_spec.rb
+++ b/spec/regressions/population_controller_spec.rb
@@ -23,7 +23,7 @@ describe PopulationController, type: :controller do
       let(:group) { groups(:schekka) }
 
       it 'does not show any approveable content if there is no current census' do
-        expect(dom.all('#content h2').count).to eq 3
+        expect(dom.all('#content h2').count).to eq 4
         expect(dom).to have_no_selector('a', text: 'Bestand bestätigen')
         expect(dom).to have_no_selector('.alert.alert-info.approveable')
         expect(dom).to have_no_selector('.alert.alert-alert.approveable')


### PR DESCRIPTION
Hallo miteinander! Erst mal, dieser Pull Request ist noch nicht merge-Reif, ich will das hier nur als Diskussionsgrundlage benutzen.

Als AL vermisse ich in der Datenbank die Möglichkeit, schnell einen Überblick über die Jahrgänge meiner Teilnehmer zu sehen, um zu sehen, wo es Löcher gibt etc.

Ich habe mal eine schnell-Version davon implementiert. Wäre es möglich, diesen Change zu integrieren? Wer muss dazu die Zustimmung geben? Falls es möglich wäre, würde ich noch refactoren, Tests hinzufügen etc.
<img width="726" alt="screen shot 2015-11-15 at 18 56 03" src="https://cloud.githubusercontent.com/assets/2587503/11170083/8ad05a30-8bca-11e5-96ef-f404671b33ed.png">
