### PR TITLE
override separator for export: optimized for MS Excel

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,11 @@ application:
     fr: Français
     it: Italiano
 
+# Presets for CSV export
+csv:
+  # optimized for M$ Excel
+  separator: ','
+  
 # The person with this email has root access to everything
 # This person should only be used by the operators of the application, not the customers.
 # Initially, a password reset token may be mailed from the application to this address to set a password.


### PR DESCRIPTION
There has been an issue in Excel with the CSV using the semicolon separator instead of the comma, because MS Excel has the `,` and not the `;` in the default settings. 

That led to the problem that excel could not automatically format the CSV to a usable list.

For the test data i had this view in Excel:
![Old export](https://www.dropbox.com/s/1tr4s33eeho02ol/hitobito_old.png?dl=1)

My change includes the override of the Settings-Parameter for the separator. By doing that, as you can see the columns are detected and the data is usable for every user. I tested also in "Numbers" for Mac, Mobile phone spreadsheet apps and it worked for all of them with the new setting.
![New export](https://www.dropbox.com/s/3fll6bzlq9gaoc4/hitobito_new.png?dl=1)

For any questions please contact me.
