### PR TITLE
Personen-ID und Primärgruppen-ID exportieren

### DIFF
--- a/app/domain/pbs/export/csv/people/people_full.rb
+++ b/app/domain/pbs/export/csv/people/people_full.rb
@@ -17,7 +17,7 @@ module Pbs
           end
 
           def person_attributes_with_pbs
-            person_attributes_without_pbs + [:pbs_number]
+            person_attributes_without_pbs + [:id, :primary_group_id, :pbs_number] 
           end
         end
       end


### PR DESCRIPTION
Die PBS führt mehrmals jährlich einen Versand an alle ihre Mitglieder durch. 
Dabei kommen jeweils mehrere Hundert Briefe wegen falscher Adressangaben zurück. Um die fehlerhaften Adressdaten einfacher an die jeweiligen Adressverantwortlichen zu melden, wird die ID der betroffenen Person sowie der Primärgruppe benötigt. So lassen sich die zurück gemeldeten Adressen nach Primärgruppe bündeln und an die öffentliche Kontaktadresse der Gruppe schicken. 

bezieht sich auf: 
https://github.com/hitobito/hitobito/issues/78
