### PR TITLE
extending adress export by group id, id and pbs-number

### DIFF
--- a/app/domain/pbs/export/csv/people/people_address.rb
+++ b/app/domain/pbs/export/csv/people/people_address.rb
@@ -28,7 +28,7 @@ module Pbs
 
           def person_attributes_with_title
             person_attributes_without_title +
-            [:title, :salutation, :correspondence_language, :kantonalverband_id]
+            [:title, :salutation, :correspondence_language, :kantonalverband_id, :id, :primary_group_id, :pbs_number]
           end
         end
       end

--- a/app/domain/pbs/export/csv/people/people_address.rb
+++ b/app/domain/pbs/export/csv/people/people_address.rb
@@ -14,7 +14,7 @@ module Pbs
 
           included do
             alias_method_chain :initialize, :kv
-            alias_method_chain :person_attributes, :title
+            alias_method_chain :person_attributes, :pbs
           end
 
           def initialize_with_kv(list)
@@ -26,10 +26,10 @@ module Pbs
             end
           end
 
-          def person_attributes_with_title
-            person_attributes_without_title +
+          def person_attributes_with_pbs
+            person_attributes_without_pbs +
             [:title, :salutation, :correspondence_language, :kantonalverband_id,
-              :id, :primary_group_id, :pbs_number]
+             :primary_group_id, :pbs_number, :id]
           end
         end
       end

--- a/app/domain/pbs/export/csv/people/people_address.rb
+++ b/app/domain/pbs/export/csv/people/people_address.rb
@@ -28,7 +28,8 @@ module Pbs
 
           def person_attributes_with_title
             person_attributes_without_title +
-            [:title, :salutation, :correspondence_language, :kantonalverband_id, :id, :primary_group_id, :pbs_number]
+            [:title, :salutation, :correspondence_language, :kantonalverband_id,
+              :id, :primary_group_id, :pbs_number]
           end
         end
       end

--- a/app/domain/pbs/export/csv/people/people_full.rb
+++ b/app/domain/pbs/export/csv/people/people_full.rb
@@ -17,7 +17,7 @@ module Pbs
           end
 
           def person_attributes_with_pbs
-            person_attributes_without_pbs + [:id, :primary_group_id, :pbs_number] 
+            person_attributes_without_pbs + [:primary_group_id, :pbs_number, :id] 
           end
         end
       end

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1024,6 +1024,8 @@ de:
         brother_and_sisters: Geschwister
         relations_to_tails: Geschwister
         kv: Kantonalverband
+        primary_group_id: ID der Hauptgruppe
+        id: ID
 
       group:
         pta: PTA

--- a/spec/domain/export/csv/people_spec.rb
+++ b/spec/domain/export/csv/people_spec.rb
@@ -12,8 +12,9 @@ describe Export::Csv::People do
 
   let(:person) { people(:bulei) }
   let(:simple_headers) do
-    %w(Vorname Nachname Pfadiname Firmenname Firma Haupt-E-Mail Adresse PLZ Ort Land
-       Geschlecht Geburtstag Rollen Titel Anrede Korrespondenzsprache Kantonalverband)
+    %W(Vorname Nachname Pfadiname Firmenname Firma Haupt-E-Mail Adresse PLZ Ort Land
+       Geschlecht Geburtstag Rollen Titel Anrede Korrespondenzsprache Kantonalverband
+       #{"ID der Hauptgruppe"} #{"PBS Personennummer"} ID)
   end
 
   describe Export::Csv::People do
@@ -40,6 +41,8 @@ describe Export::Csv::People do
         its(['Anrede']) { should eq 'Sehr geehrter Herr Dr. Leiter' }
         its(['PBS Personennummber']) { should be_nil }
         its(['Kantonalverband']) { is_expected.to eq 'CH' }
+        its(['ID']) { is_expected.to eq person.id.to_s }
+        its(['ID der Hauptgruppe']) { should eq person.primary_group_id.to_s }
       end
     end
 


### PR DESCRIPTION
Wie in https://github.com/hitobito/hitobito/issues/78 beschrieben, werden zusätzlich Attribute beim Export benötigt. Allerdings hatte @adriananderegg diese beim falschen Export hinzugefügt. 