### PR TITLE
Display event location in map

### DIFF
--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -35,3 +35,8 @@
   = render_extensions :attrs_primary, folder: 'events'
 
   = render 'attachments'
+  
+  - unless entry.is_a?(Event::Camp) && !can?(:show_details, entry)
+    - if entry.location.present?
+      %iframe{:align => "center", :name => "map", :src => "https://map.geo.admin.ch/embed.html?swisssearch=#{(entry.location).gsub(/\n/, ', ')} limit:1", :height => "300px;", :width => "90%"}
+      


### PR DESCRIPTION
Display the location of an event in the map below event details
rendered as iFrame from map.geo.admin.ch
specification according to https://help.geo.admin.ch/?id=54&lang=de

if event location is empty, map is omitted

![grafik](https://cloud.githubusercontent.com/assets/9968417/24076304/775548aa-0c2d-11e7-8b64-50f851770f26.png)
