### PR TITLE
Neue Rolle Ausbildungsverantwortlicher auf Ebene Abteilung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hitobito PBS Changelog
 
+## Version 1.X
+
+*   Neue Rolle Ausbildungsverantwortlicher auf Ebene Abteilung
+
+
 ## Version 1.17
 
 *   Bugfix: Kantonalverband wird wieder gesetzt

--- a/README.rdoc
+++ b/README.rdoc
@@ -175,6 +175,7 @@ This hitobito wagon defines the organization hierarchy with groups and roles of 
     * Redaktor: [:layer_and_below_read, :contact_data]
     * Webmaster: [:group_read, :contact_data]
     * Coach: [:layer_and_below_read, :contact_data]
+    * Verantwortlicher Ausbildung: [:group_and_below_full, :contact_data, :approve_applications]
     * Verantwortlicher Materialverkaufsstelle: [:group_read, :contact_data]
     * Verantwortlicher Pfadi Trotz Allem: [:group_read, :contact_data]
     * Verantwortlicher PR: [:group_read, :contact_data]

--- a/app/models/group/abteilung.rb
+++ b/app/models/group/abteilung.rb
@@ -182,6 +182,10 @@ class Group::Abteilung < Group
     self.permissions = [:layer_and_below_read]
   end
 
+  class VerantwortungAusbildung < ::Role
+    self.permissions = [:group_and_below_full, :contact_data, :approve_applications]
+  end
+
   class VerantwortungMaterialverkaufsstelle < ::Role
     self.permissions = [:group_read, :contact_data]
   end
@@ -227,6 +231,7 @@ class Group::Abteilung < Group
         Webmaster,
         Coach,
 
+        VerantwortungAusbildung,
         VerantwortungMaterialverkaufsstelle,
         VerantwortungPfadiTrotzAllem,
         VerantwortungPr,

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -672,6 +672,10 @@ de:
         one: Coach
         other: Coaches
         description:
+      group/abteilung/verantwortung_ausbildung:
+        one: Verantwortlicher Ausbildung
+        other: Verantwortliche Ausbildung
+        description:
       group/abteilung/verantwortung_materialverkaufsstelle:
         one: Verantwortlicher Materialverkaufsstelle
         other: Verantwortliche Materialverkaufsstelle

--- a/config/locales/models.pbs.fr.yml
+++ b/config/locales/models.pbs.fr.yml
@@ -510,6 +510,9 @@ fr:
       group/abteilung/coach:
         one: Coach
         other: Coaches
+      group/abteilung/verantwortung_ausbildung:
+        one: Responsable formation
+        other: Responsables formation
       group/abteilung/verantwortung_materialverkaufsstelle:
         one: Responsable économat scout
         other: Responsables économat scout

--- a/config/locales/models.pbs.it.yml
+++ b/config/locales/models.pbs.it.yml
@@ -524,6 +524,9 @@ it:
       group/abteilung/coach:
         one: Coach
         other: Coaches
+      group/abteilung/verantwortung_ausbildung:
+        one: Responsabile della formazione
+        other: Responsabili della formazione
       group/abteilung/verantwortung_materialverkaufsstelle:
         one: Responsabile economato
         other: Responsabili economato

--- a/spec/models/event/approval_spec.rb
+++ b/spec/models/event/approval_spec.rb
@@ -24,7 +24,7 @@ describe Event::Approval do
   [ [ 'bund', Group::Bund::Geschaeftsleitung, Group::Bund::LeitungKernaufgabeAusbildung ],
     [ 'kantonalverband', Group::Kantonalverband::Kantonsleitung, Group::Kantonalverband::VerantwortungAusbildung ],
     [ 'region', Group::Region::Regionalleitung, Group::Region::VerantwortungAusbildung ],
-    [ 'abteilung', Group::Abteilung::Abteilungsleitung, Group::Abteilung::AbteilungsleitungStv ] ].each do |layer, *roles|
+    [ 'abteilung', Group::Abteilung::Abteilungsleitung, Group::Abteilung::AbteilungsleitungStv, Group::Abteilung::VerantwortungAusbildung ] ].each do |layer, *roles|
 
       it "#roles in #{layer} equal #{roles}" do
         expect(Event::Approval.new(layer: layer).roles).to eq Array(roles)


### PR DESCRIPTION
Falls Kursfreigaben an eine Person delegiert sind, welche nicht AL oder AL-Stv. ist, sollte diese Person eine entsprechende Rolle erhalten (anstatt die AL-Stv.-Rolle zu missbrauchen).

Bezieht sich auf [hitobito/hitobito_pbs#76](https://github.com/hitobito/hitobito_pbs/issues/76).