### PR TITLE
Household export with more detail

### DIFF
--- a/app/controllers/pbs/people_controller.rb
+++ b/app/controllers/pbs/people_controller.rb
@@ -10,6 +10,7 @@ module Pbs::PeopleController
 
   included do
     alias_method_chain :prepare_tabular_entries, :layer_group
+    alias_method_chain :render_tabular_in_background, :detail
   end
 
   private
@@ -17,6 +18,13 @@ module Pbs::PeopleController
   def prepare_tabular_entries_with_layer_group(entries, full)
     entries = prepare_tabular_entries_without_layer_group(entries, full)
     entries.includes(:primary_group)
+  end
+
+  def render_tabular_in_background_with_detail(format, full, filename)
+    Export::PeopleExportJob.new(
+      format, current_person.id, person_filter,
+      params.slice(:household, :household_details).merge(full: full, filename: filename)
+    ).enqueue!
   end
 
 end

--- a/app/controllers/pbs/subscriptions_controller.rb
+++ b/app/controllers/pbs/subscriptions_controller.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Pbs::SubscriptionsController
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :render_tabular_in_background, :detail
+  end
+
+  def render_tabular_in_background_with_detail(format)
+    with_async_download_cookie(format, "subscriptions_#{mailing_list.id}") do |filename|
+      Export::SubscriptionsJob.new(format,
+                                   current_person.id, mailing_list.id,
+                                   params.slice(:household, :household_details)
+                                    .merge(filename: filename)).enqueue!
+    end
+  end
+
+end

--- a/app/domain/pbs/export/tabular/people/households_full.rb
+++ b/app/domain/pbs/export/tabular/people/households_full.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+#  Copyright (c) 2018, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Pbs::Export::Tabular::People
+  class HouseholdsFull < Export::Tabular::People::Households
+
+    def person_attributes
+      super +
+      [:correspondence_language, :kantonalverband_id,
+       :id, :layer_group_id, :company_name, :company]
+    end
+  end
+end

--- a/app/domain/pbs/export/tabular/people/participations_households_full.rb
+++ b/app/domain/pbs/export/tabular/people/participations_households_full.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+#  Copyright (c) 2018-2018, hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::Tabular::People
+  class ParticipationsHouseholdsFull < HouseholdsFull
+    def initialize(list)
+      super(people(list))
+    end
+
+    def people(list)
+      list.map(&:person)
+    end
+  end
+end

--- a/app/helpers/pbs/dropdown/people_export.rb
+++ b/app/helpers/pbs/dropdown/people_export.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs
+  module Dropdown
+    module PeopleExport
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method_chain :tabular_links, :detail
+      end
+
+      def tabular_links_with_detail(format)
+        tabular_links_without_detail(format)
+        path = params.merge(format: format)
+        item = @items.find { |i| i.label == translate(format) }
+        item.sub_items << ::Dropdown::Item.new(translate(:household_details),
+        path.merge(household_details: true))
+      end
+
+    end
+  end
+end

--- a/app/jobs/pbs/export/event_participations_export_job.rb
+++ b/app/jobs/pbs/export/event_participations_export_job.rb
@@ -13,7 +13,9 @@ module Pbs::Export::EventParticipationsExportJob
   end
 
   def exporter_with_detail
-    return Pbs::Export::Tabular::People::ParticipationsHouseholdsFull if  @options[:household_details]
+    if @options[:household_details]
+      return Pbs::Export::Tabular::People::ParticipationsHouseholdsFull
+    end
     exporter_without_detail
   end
 

--- a/app/jobs/pbs/export/event_participations_export_job.rb
+++ b/app/jobs/pbs/export/event_participations_export_job.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::EventParticipationsExportJob
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :exporter, :detail
+  end
+
+  def exporter_with_detail
+    return Pbs::Export::Tabular::People::ParticipationsHouseholdsFull if  @options[:household_details]
+    exporter_without_detail
+  end
+
+end

--- a/app/jobs/pbs/export/people_export_job.rb
+++ b/app/jobs/pbs/export/people_export_job.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::PeopleExportJob
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :exporter, :detail
+  end
+
+  def exporter_with_detail
+    return Pbs::Export::Tabular::People::HouseholdsFull if  @options[:household_details]
+    exporter_without_detail
+  end
+
+end

--- a/app/jobs/pbs/export/subscriptions_job.rb
+++ b/app/jobs/pbs/export/subscriptions_job.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::SubscriptionsJob
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :exporter, :detail
+  end
+
+  def exporter_with_detail
+    return Pbs::Export::Tabular::People::HouseholdsFull if  @options[:household_details]
+    exporter_without_detail
+  end
+
+end

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -44,6 +44,9 @@ de:
   dropdown/event/camp_participant_status:
     change_state: Status ändern
 
+  dropdown/people_export:
+    household_details: 'Haushaltsliste mit Details'
+
   export/pdf/camp_application:
     title: Lageranmeldung %{camp}
     group_header: Abteilung und Einheit

--- a/config/locales/views.pbs.fr.yml
+++ b/config/locales/views.pbs.fr.yml
@@ -31,6 +31,10 @@ fr:
         usage_advise: Les données de la base de données de membres ne peuvent être utilisées qu'en lien avec des activités scoutes. Par exemple, il est interdit de les transmettre à des tiers ou à d'autres organisations. Le traitement et l'utilisation des données sont soumises aux règles de la bonne foi et doivent être proportionnés.
   dropdown/event/camp_participant_status:
     change_state: Changer le statut
+
+  dropdown/people_export:
+    household_details: 'Liste des foyers complète'
+
   export/pdf/camp_application:
     title: Annonce de camp %{camp}
     group_header: Groupe et unité

--- a/config/locales/views.pbs.it.yml
+++ b/config/locales/views.pbs.it.yml
@@ -31,6 +31,10 @@ it:
         usage_advise: I dati della banca dati degli attivi possono essere utilizzati unicamente in un contesto di attività scout, non possono ad esempio essere inoltrate a terzi o ad altre organizzazioni. L'elaborazione e l'utilizzo devono avvenire in buona fede e in modo proporzionato.
   dropdown/event/camp_participant_status:
     change_state: Modificare lo stato
+
+  dropdown/people_export:
+    household_details: 'Elenco delle famiglie (completo)'
+
   export/pdf/camp_application:
     title: Annuncio di campo %{camp}
     group_header: Sezione e unità

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -59,6 +59,15 @@ module HitobitoPbs
       Export::Tabular::People::PeopleFull.send(
         :include, Pbs::Export::Tabular::People::PeopleFull
       )
+      Export::PeopleExportJob.send(
+        :include, Pbs::Export::PeopleExportJob
+      )
+      Export::EventParticipationsExportJob.send(
+        :include, Pbs::Export::EventParticipationsExportJob
+      )
+      Export::SubscriptionsJob.send(
+        :include, Pbs::Export::SubscriptionsJob
+      )
       Export::Tabular::Events::BsvRow.send :include, Pbs::Export::Tabular::Events::BsvRow
 
       ### abilities
@@ -94,6 +103,7 @@ module HitobitoPbs
       GroupsController.send :include, Pbs::GroupsController
       PeopleController.send :include, Pbs::PeopleController
       EventsController.send :include, Pbs::EventsController
+      SubscriptionsController.send :include, Pbs::SubscriptionsController
       Event::ApplicationMarketController.send :include, Pbs::Event::ApplicationMarketController
       Event::ListsController.send :include, Pbs::Event::ListsController
       Event::ParticipationsController.send :include, Pbs::Event::ParticipationsController
@@ -106,7 +116,8 @@ module HitobitoPbs
 
       ### helpers
       FilterNavigation::Events.send :include, Pbs::FilterNavigation::Events
-
+      Dropdown::PeopleExport.send :include, Pbs::Dropdown::PeopleExport
+      
       ### jobs
       Event::ParticipationConfirmationJob.send :include, Pbs::Event::ParticipationConfirmationJob
 

--- a/spec/domain/export/tabular/people/households_spec.rb
+++ b/spec/domain/export/tabular/people/households_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+#  Copyright (c) 2012-2018, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Pbs::Export::Tabular::People::HouseholdsFull do
+
+  let(:leader) { people(:top_leader) }
+  let(:member) { people(:bottom_member) }
+
+  def households(list = [])
+    Pbs::Export::Tabular::People::HouseholdsFull.new(list)
+  end
+
+  context 'header' do
+    it 'includes name, address attributes and layer group columns' do
+      expect(households.attributes).to eq [:name, :address, :zip_code, :town,
+                                           :country, :layer_group, :correspondence_language,
+                                           :kantonalverband_id, :id, :layer_group_id,
+                                           :company_name, :company]
+    end
+  end
+
+end


### PR DESCRIPTION
This Pull Request replaces https://github.com/hitobito/hitobito_pbs/pull/84. 

**Changes**
Adds a new export option "full" on household lists (persons, subscriptions and now also participations). The export contains details like the company fields or the person-id, which are particularly useful for (physical) mailings.