### PR TITLE
Add confirm to crisis button

### DIFF
--- a/app/views/groups/_actions_show_pbs.html.haml
+++ b/app/views/groups/_actions_show_pbs.html.haml
@@ -8,4 +8,4 @@
     = action_button(t('.crisis_done'), group_crisis_path(@group, @group.active_crisis), :check, method: :patch)
 
   - unless @group.active_crisis
-    = action_button(t('.crisis'), group_crises_path(@group), :medkit, method: :post, class: 'btn-danger')
+    = action_button(t('.crisis'), group_crises_path(@group), :medkit, method: :post, class: 'btn-danger', data: { confirm: t('.confirm_crisis') })

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -246,6 +246,7 @@ de:
     actions_show_pbs:
       crisis: Krise
       crisis_done: Krise quittieren
+      confirm_crisis: Bist du sicher, dass du die Krise auf der Gruppe auslösen möchtest. Die Zuständigen Krisenteams werden über deinen Zugriff informiert. Bitte gehe sorgsam mit den Daten um.
 
   member_counts:
     created_data_for_year: Die Zahlen von Total %{total} Mitgliedern wurden für %{year} erfolgreich erzeugt.


### PR DESCRIPTION
It's now too easy to accidentally start a crisis.  This PR adds a confirmation dialog:

![image](https://user-images.githubusercontent.com/939106/64473585-cd23f300-d168-11e9-8ea2-411a3253f8b2.png)
