### PR TITLE
Icon für Navigationspunkt "Lager"

### DIFF
--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -127,6 +127,7 @@ module HitobitoPbs
       NavigationHelper::MAIN.insert(
         i + 1,
         label: :camps,
+        icon_name: :hotel,
         url: :list_camps_path,
         active_for: %w(list_all_camps
                        list_camps_abroad


### PR DESCRIPTION
Das Zelt ist in der Version des Iconsets leider nicht verfügbar, darum wurde dieses ausgewählt:

![grafik](https://user-images.githubusercontent.com/656013/64537287-d5bc2b00-d31a-11e9-9392-999a8e2a2408.png)