### PR TITLE
Schatten-Farbe der Sheets ändern zu neutralem transparentem Schwarz

### DIFF
--- a/app/assets/stylesheets/hitobito/customizable/_wagon.scss
+++ b/app/assets/stylesheets/hitobito/customizable/_wagon.scss
@@ -1,4 +1,9 @@
 /* Content */
+
+.sheet.parent, #content {
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.4);
+}
+
 #page {
   padding: 5px 10px 90px;
   margin: 0;


### PR DESCRIPTION
Bisher war die Schattenfarbe grün (hitobito-grün anstatt PBS-grün!), hiermit wird sie auf ein zurückhaltenderes Schwarz geändert 😅 

![Color of Sheet Shadow](https://user-images.githubusercontent.com/656013/64537725-aa860b80-d31b-11e9-841d-f8a9c2479da5.jpg)
