### PR TITLE
Hilfeseiten mit Links zu den Leitfäden der PBS

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,0 +1,12 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class HelpController < ApplicationController
+
+  skip_authorization_check only: [:index]
+
+  def index; end
+
+end

--- a/app/views/help/index.html.haml
+++ b/app/views/help/index.html.haml
@@ -1,0 +1,20 @@
+-#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+-#  hitobito_pbs and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_pbs.
+
+- title t('.title')
+
+%p= t('.description_html')
+
+%h2= t('.guides.title')
+%p= t('.guides.description')
+
+%table.table.table-striped
+  %tbody
+    - %w(hering coaches ticket anker pilot).each do |help_key|
+      %tr
+        %td
+          %strong= link_to t(".guides.#{help_key}.title"), t(".guides.#{help_key}.url"), target: '_blank'
+        %td
+          = t(".guides.#{help_key}.description")

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -247,6 +247,34 @@ de:
       crisis: Krise
       crisis_done: Krise quittieren
 
+  help:
+    index:
+      title: Hilfe
+      description_html: Informationen zu den neusten Releases findest Du <a href="https://www.scout.ch/de/pfadi-online/midata/release/" target="_blank">hier</a>.
+      guides:
+        title: Leitfäden
+        description: "Diese Leitfäden helfen dir bei der Administration von Kursen und Lagern:"
+        hering:
+          url: http://hering.scouts.ch
+          title: "Hering: Leitfaden zur Administration von Pfadilagern"
+          description: "Der Hering bietet dir sämtliche Informationen zur Administration von Pfadilagern. Er führt dich Schritt für Schritt durch alle wichtigen Dokumente. Mit diesem Leitfaden wirst du keinen wichtigen Punkt vergessen."
+        coaches:
+          url: http://coaches.scouts.ch
+          title: 1x1 MiData für Coaches
+          description: "Das «1x1 MiData für Coaches» erläutert die für Coaches wichtigsten Funktionen der PBS-Mitgliederdatenbank (Mi- Data). Es dient sowohl als Factsheet, als auch als Vorbereitung für das MF-Coach und den Coachkurs."
+        anker:
+          url: http://anker.scouts.ch
+          title: "Anker: Leitfaden zur PBS Kursadministration"
+          description: "Für Kursleiter/innen und Leiterkursbetreuer/innen: Alle administrativen Vorgänge, die bei der Anmeldung und Durchführung eines J+S- oder BSV-Kurses beachtet werden müssen, sind hier detailliert beschrieben."
+        pilot:
+          url: http://pilot.scouts.ch
+          title: "Pilot: Leitfaden zur PBS-Kursadministration in der MiData und der NDBJS"
+          description: "Leitfaden für Sekretariate und kantonale Ausbildungsverantwortliche zur Kursadministration in der MiData und der NDBJS"
+        ticket:
+          url: http://ticket.scouts.ch
+          title: "Ticket: Leitfaden zur Anmeldung von Kursteilnehmenden"
+          description: "Das Ticket beschreibt den TN-Anmeldeprozess über die MiData (Mitgliederdatenbank der PBS)"
+
   member_counts:
     created_data_for_year: Die Zahlen von Total %{total} Mitgliedern wurden für %{year} erfolgreich erzeugt.
     updated_data_for_year: Die Mitgliederzahlen für %{year} wurden erfolgreich gespeichert.
@@ -256,6 +284,7 @@ de:
 
   navigation:
     camps: Lager
+    help: Hilfe
 
   people:
     fields:

--- a/config/locales/views.pbs.fr.yml
+++ b/config/locales/views.pbs.fr.yml
@@ -213,6 +213,21 @@ fr:
       population: Effectifs
       statistic: Statistiques
       approvals: Validation du cours (%{count})
+  help:
+    index:
+      title: Aide
+      guides:
+        title: Guides
+        hering:
+          url: http://heringfr.scouts.ch
+        coaches:
+          url: http://coachesfr.scouts.ch
+        anker:
+          url: http://ankerfr.scouts.ch
+        pilot:
+          url: http://pilotfr.scouts.ch
+        ticket:
+          url: http://ticketfr.scouts.ch
   member_counts:
     created_data_for_year: Les données de %{total} membres au total ont été créées avec succès pour l'année %{year}.
     updated_data_for_year: Les effectifs pour l'année %{year} ont été sauvegardés avec succès.
@@ -221,6 +236,7 @@ fr:
       title: Editer les effectifs %{year}
   navigation:
     camps: Camp
+    help: Aide
   people:
     fields:
       no_sensitive_information: Ne pas saisir de données personnelles sensibles dans ce champ.

--- a/config/locales/views.pbs.it.yml
+++ b/config/locales/views.pbs.it.yml
@@ -213,6 +213,21 @@ it:
       population: Censimento dei membri
       statistic: Statistica
       approvals: Attivazione del corso (%{count})
+  help:
+    index:
+      title: Aiuto
+      guides:
+        title: Guide
+        hering:
+          url: http://heringit.scouts.ch
+        coaches:
+          url: http://coachesfr.scouts.ch
+        anker:
+          url: http://ankerit.scouts.ch
+        pilot:
+          url: http://pilotit.scouts.ch
+        ticket:
+          url: http://ticketit.scouts.ch
   member_counts:
     created_data_for_year: I censimenti per %{total} attivi nell'anno %{year} sono stati generati con successo.
     updated_data_for_year: Il numero dei membri per il %{year} è stato registrato con successo.
@@ -221,6 +236,7 @@ it:
       title: Aggiornare il numero dei membri per il %{year}
   navigation:
     camps: Campi
+    help: Aiuto
   people:
     fields:
       no_sensitive_information: Non includere in questo campo nessun dato personale particolarmente sensibile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
 
     resources :black_lists
 
+    get 'help' => 'help#index'
+
   end
 
 

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -138,6 +138,13 @@ module HitobitoPbs
             can?(:list_cantonal, Event::Camp)
         end
       )
+      index_admin = NavigationHelper::MAIN.index { |opts| opts[:label] == :admin }
+      NavigationHelper::MAIN.insert(
+        index_admin,
+        label: :help,
+        icon_name: :'info-circle',
+        url: :help_path
+      )
 
       # rubocop:enable SingleSpaceBeforeFirstArg
 


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/656013/64539672-30f01c80-d31f-11e9-8fa4-fc9698a292d3.png)

Fügt einen neuen Navigationspunkt «Hilfe» hinzu, der einen allgemeinen Hilfetext (Hinweis auf Release Notes der PBS) und eine Liste der existierenden Leitfäden enthält. Die Listeneinträge verlinken auf existierende Leitfäden als PBS, welche extern gehostet werden.