### PR TITLE
Kurse: Ungesicherte Werte in der «Anwesenheits»-Ansicht kennzeichnen

### DIFF
--- a/app/views/event/attendances/_list.html.haml
+++ b/app/views/event/attendances/_list.html.haml
@@ -23,3 +23,5 @@
                            step: 0.5,
                            size: 10,
                            class: 'span2')
+        - if p.bsv_days.nil?
+          %span.muted{ style: 'float:xleft;' }= t('.not_persisted')

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -82,7 +82,8 @@ de:
         leaders: Leitung
         cooks: Küche
         participants: Teilnehmende
-
+      list:
+        not_persisted: Noch nicht gespeichert
     lists:
       nav_left_camps:
         all_camps: Lager ganze Schweiz


### PR DESCRIPTION
Bei einem existierenden Kurs werden im Tab «Anwesenheit» die gespeicherten Werte für jede teilnehmende Person angezeigt und können verändert werden. Wenn jedoch noch kein Wert für eine Person gespeichert wird und ein «BSV-Tage»-Wert auf dem Kurs hinterlegt ist, wird dieser in das Textfeld geschrieben. Dies führt zu der Situation, dass nicht klar ist, ob dieser Wert gespeichert ist oder nicht – und man aus Erfahrung wissen muss, dass diese Seite einfach mal abgesendet werden muss, damit die Werte sicher gespeichert sind. 

Um diesen Ablauf zu verbessern, fügt dieser PR neben dem Feld ein Hinweis «Noch nicht gespeichert» ein, falls der Wert der Standardwert ist und noch nicht gespeichert wurde.

![grafik](https://user-images.githubusercontent.com/656013/64543481-9810cf80-d325-11e9-9589-78b008e02f16.png)
