### PR TITLE
change permission for bundes_kommission

### DIFF
--- a/app/models/group/bundes_kommission.rb
+++ b/app/models/group/bundes_kommission.rb
@@ -43,6 +43,14 @@ class Group::BundesKommission < Group::Kommission
 
   children Group::BundesKommission
 
+  class Leitung < Group::Kommission::Leitung
+    self.permissions = [:layer_read, :group_and_below_full]
+  end
+
+  class Mitglied < Group::Kommission::Mitglied
+    self.permissions = [:layer_read]
+  end
+
   roles Leitung, Mitglied
   self.default_role = Mitglied
 end

--- a/db/migrate/20190921151245_migrate_bundes_kommission_roles.rb
+++ b/db/migrate/20190921151245_migrate_bundes_kommission_roles.rb
@@ -1,0 +1,11 @@
+class MigrateBundesKommissionRoles < ActiveRecord::Migration
+  def change
+    bundes_group_ids = Group.where(type: 'Group::BundesKommission').select(:id)
+    bundes_mitglieder = Role.where(type: 'Group::Kommission::Mitglied').where(group_id: bundes_group_ids)
+    bundes_leitung = Role.where(type: 'Group::Kommission::Leitung').where(group_id: bundes_group_ids)
+    Role.transaction do
+      bundes_mitglieder.update_all(type: 'Group::BundesKommission::Mitglied')
+      bundes_leitung.update_all(type: 'Group::BundesKommission::Leitung')
+    end
+  end
+end


### PR DESCRIPTION
change permissions for `bundes_kommission`:
- Leitung :layer_read, :group_and_below_full
- Mitglied :layer_read

and migrate existing Roles to the new ` Group::BundesKommission::...`