### PR TITLE
Lagerhierachien: Lager als übergeordnetes Lager kennzeichnen

### DIFF
--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -135,6 +135,8 @@ class Event::Camp < Event
   ### VALIDATIONS
 
   validates :state, inclusion: possible_states
+  validate :may_become_sub_camp, if: :parent_id_changed?
+  validate :must_allow_sub_camps, if: 'sub_camps.any?'
 
   ### CALLBACKS
 
@@ -252,6 +254,18 @@ class Event::Camp < Event
       Group::Region.sti_name => Group::Region::Regionalleitung.sti_name,
       Group::Abteilung.sti_name => Group::Abteilung::Abteilungsleitung.sti_name
     }
+  end
+
+  def may_become_sub_camp
+    unless super_camp.allow_sub_camps
+      errors.add(:parent_id, :invalid)
+    end
+  end
+
+  def must_allow_sub_camps
+    unless allow_sub_camps
+      errors.add(:allow_sub_camps, :invalid)
+    end
   end
 
 end

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -122,6 +122,15 @@ class Event::Camp < Event
   self.revoked_participation_states = %w(canceled absent)
   self.countable_participation_states = %w(applied_electronically assigned absent)
 
+  ### RELATIONS
+
+  belongs_to :super_camp, class_name: name, foreign_key: :parent_id
+  has_many :sub_camps,
+           class_name: name,
+           foreign_key: :parent_id,
+           inverse_of: :super_camp,
+           dependent: :restrict_with_error
+
 
   ### VALIDATIONS
 

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -99,8 +99,10 @@ class Event::Camp < Event
 
   include Event::RestrictedRole
 
-  self.used_attributes += [:state, :group_ids,
-                           :participants_can_apply, :participants_can_cancel]
+  self.used_attributes += [
+    :state, :group_ids, :participants_can_apply, :participants_can_cancel,
+    :parent_id, :allow_sub_camps
+  ]
 
   self.used_attributes -= [:contact_id, :applications_cancelable]
 

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
+
 # == Schema Information
 #
 # Table name: events
@@ -206,7 +207,7 @@ class Event::Camp < Event
   end
 
   def advisor_changed_except_in_created?(advisor_key)
-    restricted_role_changes[advisor_key] && state != 'created' && !state.blank?
+    restricted_role_changes[advisor_key] && state != 'created' && state.present?
   end
 
   def send_abteilungsleitung_assignment_info

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -136,7 +136,7 @@ class Event::Camp < Event
 
   validates :state, inclusion: possible_states
   validate :may_become_sub_camp, if: :parent_id_changed?
-  validate :must_allow_sub_camps, if: 'sub_camps.any?'
+  validates :allow_sub_camps, acceptance: true, if: 'sub_camps.any?'
 
   ### CALLBACKS
 
@@ -259,12 +259,6 @@ class Event::Camp < Event
   def may_become_sub_camp
     unless super_camp.allow_sub_camps
       errors.add(:parent_id, :invalid)
-    end
-  end
-
-  def must_allow_sub_camps
-    unless allow_sub_camps
-      errors.add(:allow_sub_camps, :invalid)
     end
   end
 

--- a/app/views/events/_fields_pbs.html.haml
+++ b/app/views/events/_fields_pbs.html.haml
@@ -38,3 +38,8 @@
 
   = render 'expected_participants_fields', f: f
 
+  - entry.used?(:parent_id) do
+    = field_set_tag t('event.hierarchy') do
+      -# = f.labeled_button :attach_to_super_camp
+      = f.labeled_check_box :allow_sub_camps, readonly: entry.sub_camps.any?
+

--- a/app/views/events/_fields_pbs.html.haml
+++ b/app/views/events/_fields_pbs.html.haml
@@ -41,5 +41,8 @@
   - entry.used?(:parent_id) do
     = field_set_tag t('event.hierarchy') do
       -# = f.labeled_button :attach_to_super_camp
-      = f.labeled_check_box :allow_sub_camps, readonly: entry.sub_camps.any?
+      = f.labeled(:allow_sub_camps, '&nbsp;'.html_safe) do
+        = f.boolean_field :allow_sub_camps,
+                          caption: Event::Camp.human_attribute_name(:allow_sub_camps),
+                          readonly: entry.sub_camps.any?
 

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2017, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -1053,6 +1053,7 @@ de:
         coach: Coach
         advisor_unassigned: Niemand zugeordnet
         leader_unassigned: Keine Leitenden erfasst
+        allow_sub_camps: untergeordnete Lager zulassen
 
       event/course:
         requires_approval: Empfehlung der Anmeldungen nötig durch

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2017, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -103,6 +103,7 @@ de:
         title: Alle Lager im Ausland
         explanation: 'Hier werden alle Lager, welche im Ausland stattfinden angezeigt. Dabei werden nur Lager berücksichtigt, welche eingereicht wurden und deren Status bestätigt oder höher ist und die nicht abgesagt sind.'
       advanced_bsv_export_button: Erweiterter BSV/LKB Export
+    hierarchy: Lagerhierarchie
 
     participations:
       canceled_own_notice: Du wurdest von diesem Anlass abgemeldet.

--- a/db/migrate/20191002124400_add_hierarchies_to_camps.rb
+++ b/db/migrate/20191002124400_add_hierarchies_to_camps.rb
@@ -3,7 +3,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
 
-class AddHierarchiesToCampyEvents < ActiveRecord::Migration
+class AddHierarchiesToCamps < ActiveRecord::Migration
   def change
     add_column :events, :parent_id, :integer, null: true
     add_column :events, :allow_sub_camps, :boolean, null: false, default: false

--- a/db/migrate/20191002124400_add_hierarchies_to_campy_events.rb
+++ b/db/migrate/20191002124400_add_hierarchies_to_campy_events.rb
@@ -1,0 +1,12 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class AddHierarchiesToCampyEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :parent_id, :integer, null: true
+    add_column :events, :allow_sub_camps, :boolean, null: false, default: false
+  end
+end
+

--- a/spec/fixtures/event/dates.yml
+++ b/spec/fixtures/event/dates.yml
@@ -30,3 +30,9 @@ fourth:
   event: bund_course
   start_at: <%= Time.zone.parse("2012-6-01") %>
   finish_at: <%= Time.zone.parse("2012-6-08") %>
+
+fifth:
+  label: Lager
+  event: bund_camp
+  start_at: <%= Time.zone.parse("2012-6-01") %>
+  finish_at: <%= Time.zone.parse("2012-6-08") %>

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -115,3 +115,8 @@ schekka_camp:
   name: Sommerlager
   groups: schekka
   type: Event::Camp
+
+bund_camp:
+  name: Sammellager
+  groups: bund
+  type: Event::Camp

--- a/spec/models/event/camp_spec.rb
+++ b/spec/models/event/camp_spec.rb
@@ -640,10 +640,13 @@ describe Event::Camp do
       before { subject.update_attribute(:allow_sub_camps, false) }
 
       it 'is invalid if sub_camps are added' do
+        sub_camp = events(:schekka_camp)
         expect do
-          subject.sub_camps << events(:schekka_camp)
+          subject.sub_camps << sub_camp
+
           is_expected.to_not be_valid
-        end.to_not change { subject.sub_camps.size }
+          expect(sub_camp).to_not be_valid
+        end.to_not change { subject.reload.sub_camps.size }
       end
 
       it 'does not have sub_camps' do

--- a/spec/models/event/camp_spec.rb
+++ b/spec/models/event/camp_spec.rb
@@ -1,4 +1,8 @@
-# encoding: utf-8
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
 # == Schema Information
 #
 # Table name: events
@@ -86,11 +90,6 @@
 #  bsv_days                          :decimal(6, 2)
 #
 
-
-#  Copyright (c) 2012-2016, Pfadibewegung Schweiz. This file is part of
-#  hitobito_pbs and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito_pbs.
 
 require 'spec_helper'
 
@@ -520,7 +519,7 @@ describe Event::Camp do
         expect(subject).to be_valid
         clear_attribute(subject, a)
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages.first).to match /muss ausgefüllt werden/
+        expect(subject.errors.full_messages.first).to match(/muss ausgefüllt werden/)
       end
     end
 


### PR DESCRIPTION
Ich habe die Lagerhierarchien vorerst ohne nested set implementiert. Ich habe damit auch noch keine Annahmen über die Anzahl der Hierarchieebenen im Code festgehalten. Für eine Ebene (Sammellager + Unterlager) ist es so komplett ausreichend. Auch, um erstmal das restliche Interface anzulegen. 

Sobald mehrere Ebene unterstützt werden sollen, sollten wir den Rest der nested_set-Methoden hinzufügen. Genauso fehlt vielleicht noch einen Methode, die ein Lager explizit als Sammellager oder Unterlager kennzeichnet (`super_camp?` und `sub_camp?`). Dies ist bisher nur über das Vorhandensein einer entsprechenden Relation zu erkennen.

Ich wollte hiermit aber mal einen Start machen und bitte um ein Review.

See hitobito/hitobito#830