### PR TITLE
Übergeordnetes Lager anzeigen

### DIFF
--- a/app/assets/stylesheets/hitobito/customizable/_wagon.scss
+++ b/app/assets/stylesheets/hitobito/customizable/_wagon.scss
@@ -65,7 +65,3 @@ table tr.grouping td {
 [data-remove-supercamp] {
   @extend .remove_nested_fields
 }
-
-dl.dl-horizontal.multiline dt {
-  white-space: normal;
-}

--- a/app/assets/stylesheets/hitobito/customizable/_wagon.scss
+++ b/app/assets/stylesheets/hitobito/customizable/_wagon.scss
@@ -65,3 +65,7 @@ table tr.grouping td {
 [data-remove-supercamp] {
   @extend .remove_nested_fields
 }
+
+dl.dl-horizontal.multiline dt {
+  white-space: normal;
+}

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -62,7 +62,7 @@ class SupercampsController < ApplicationController
 
   def matching_supercamps
     Event::Camp.where('name LIKE ?', "%#{params[:q]}%")
-      .where(allow_sub_camps: true, state: 'created')
+               .where(allow_sub_camps: true, state: 'created')
   end
 
   def camp_id
@@ -79,7 +79,7 @@ class SupercampsController < ApplicationController
 
   def supercamp_attrs
     @supercamp_attrs ||= supercamp.attributes.except(*EXCLUDED_SUPERCAMP_ATTRS)
-                           .merge({ dates_attributes: dates_attributes })
+                                  .merge(dates_attributes: dates_attributes)
   end
 
   def generated_name

--- a/app/helpers/pbs/sheet/event.rb
+++ b/app/helpers/pbs/sheet/event.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2017, 2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -20,6 +20,11 @@ module Pbs::Sheet::Event
                      :attendances_group_event_path,
                      if: (lambda do |view, _group, event|
                        event.course_kind? && view.can?(:manage_attendances, event)
+                     end)),
+      Sheet::Tab.new('events.tabs.sub_camps',
+                     :group_event_path, # :group_event_subcamps_path,
+                     if: (lambda do |_view, _group, event|
+                       event.allow_sub_camps
                      end))
     )
   end

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -117,9 +117,9 @@ class Event::Camp < Event
   # states are used for workflow
   # translations in config/locales
   self.possible_states = %w(created confirmed assignment_closed canceled closed)
-  self.possible_participation_states = %w(applied_electronically assigned canceled absent)
-  self.active_participation_states = %w(applied_electronically assigned)
-  self.revoked_participation_states = %w(canceled absent)
+  self.possible_participation_states  = %w(applied_electronically assigned canceled absent)
+  self.active_participation_states    = %w(applied_electronically assigned)
+  self.revoked_participation_states   = %w(canceled absent)
   self.countable_participation_states = %w(applied_electronically assigned absent)
 
   ### RELATIONS
@@ -131,11 +131,10 @@ class Event::Camp < Event
            inverse_of: :super_camp,
            dependent: :restrict_with_error
 
-
   ### VALIDATIONS
 
   validates :state, inclusion: possible_states
-  validate :may_become_sub_camp, if: :parent_id_changed?
+  validate  :may_become_sub_camp, if: :parent_id_changed?
   validates :allow_sub_camps, acceptance: { accept: true }, if: 'sub_camps.any?'
 
   ### CALLBACKS

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -124,6 +124,9 @@ class Event::Camp < Event
 
   ### RELATIONS
 
+  # this is defined in lib/hitobito_pbs/wagon.rb due to loading issues:
+  # acts_as_nested_set dependent: :nullify
+
   belongs_to :super_camp, class_name: name, foreign_key: :parent_id
   has_many :sub_camps,
            class_name: name,

--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -24,6 +24,14 @@
     - unless entry.is_a?(Event::Camp) && !can?(:show_details, entry)
       = labeled(t('event.run_by'), entry.group_names)
 
+    - if entry.is_a?(Event::Camp) && entry.sub_camps.any?
+      %dl.dl-horizontal.dl-borderless.multiline
+        = labeled(t(:'events.fields_pbs.direct_subcamps')) do
+          %ul
+            - entry.sub_camps.each do |camp|
+              %li
+                = link_to(camp, camp)
+
     - entry.used?(:state) do
       = labeled_attr(entry, :state_translated)
 

--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -24,13 +24,18 @@
     - unless entry.is_a?(Event::Camp) && !can?(:show_details, entry)
       = labeled(t('event.run_by'), entry.group_names)
 
-    - if entry.is_a?(Event::Camp) && entry.sub_camps.any?
-      %dl.dl-horizontal.dl-borderless.multiline
-        = labeled(t(:'events.fields_pbs.direct_subcamps')) do
-          %ul
-            - entry.sub_camps.each do |camp|
-              %li
-                = link_to(camp, camp)
+    - if entry.is_a?(Event::Camp)
+      - if entry.sub_camps.any?
+        %dl.dl-horizontal.multiline
+          = labeled(t(:'events.fields_pbs.direct_subcamps')) do
+            %ul
+              - entry.sub_camps.each do |camp|
+                %li
+                  = link_to(camp, camp)
+      - if entry.super_camp.present?
+        %dl.dl-horizontal.multiline
+          = labeled(t(:'events.fields_pbs.supercamp')) do
+            = link_to(entry.super_camp, entry.super_camp)
 
     - entry.used?(:state) do
       = labeled_attr(entry, :state_translated)

--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -28,17 +28,17 @@
       = labeled_attr(entry, :state_translated)
 
   - if entry.is_a?(Event::Camp)
-    - if entry.sub_camps.any?
+    - if entry.super_camp.present?
+      %dl.dl-horizontal.multiline
+        = labeled(t(:'events.fields_pbs.supercamp')) do
+          = link_to(entry.super_camp, entry.super_camp)
+    - elsif entry.sub_camps.any?
       %dl.dl-horizontal.multiline
         = labeled(t(:'events.fields_pbs.direct_subcamps')) do
           %ul
             - entry.sub_camps.each do |camp|
               %li
                 = link_to(camp, camp)
-    - if entry.super_camp.present?
-      %dl.dl-horizontal.multiline
-        = labeled(t(:'events.fields_pbs.supercamp')) do
-          = link_to(entry.super_camp, entry.super_camp)
 
   = render_present_attrs(entry, :description)
 

--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -24,21 +24,21 @@
     - unless entry.is_a?(Event::Camp) && !can?(:show_details, entry)
       = labeled(t('event.run_by'), entry.group_names)
 
-    - if entry.is_a?(Event::Camp)
-      - if entry.sub_camps.any?
-        %dl.dl-horizontal.multiline
-          = labeled(t(:'events.fields_pbs.direct_subcamps')) do
-            %ul
-              - entry.sub_camps.each do |camp|
-                %li
-                  = link_to(camp, camp)
-      - if entry.super_camp.present?
-        %dl.dl-horizontal.multiline
-          = labeled(t(:'events.fields_pbs.supercamp')) do
-            = link_to(entry.super_camp, entry.super_camp)
-
     - entry.used?(:state) do
       = labeled_attr(entry, :state_translated)
+
+  - if entry.is_a?(Event::Camp)
+    - if entry.sub_camps.any?
+      %dl.dl-horizontal.multiline
+        = labeled(t(:'events.fields_pbs.direct_subcamps')) do
+          %ul
+            - entry.sub_camps.each do |camp|
+              %li
+                = link_to(camp, camp)
+    - if entry.super_camp.present?
+      %dl.dl-horizontal.multiline
+        = labeled(t(:'events.fields_pbs.supercamp')) do
+          = link_to(entry.super_camp, entry.super_camp)
 
   = render_present_attrs(entry, :description)
 

--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -27,18 +27,9 @@
     - entry.used?(:state) do
       = labeled_attr(entry, :state_translated)
 
-  - if entry.is_a?(Event::Camp)
-    - if entry.super_camp.present?
-      %dl.dl-horizontal.multiline
-        = labeled(t(:'events.fields_pbs.supercamp')) do
-          = link_to(entry.super_camp, entry.super_camp)
-    - elsif entry.sub_camps.any?
-      %dl.dl-horizontal.multiline
-        = labeled(t(:'events.fields_pbs.direct_subcamps')) do
-          %ul
-            - entry.sub_camps.each do |camp|
-              %li
-                = link_to(camp, camp)
+  - if entry.is_a?(Event::Camp) && entry.super_camp.present?
+    %dl.dl-horizontal
+      = labeled_attr(entry, :super_camp)
 
   = render_present_attrs(entry, :description)
 

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1054,6 +1054,7 @@ de:
         advisor_unassigned: Niemand zugeordnet
         leader_unassigned: Keine Leitenden erfasst
         allow_sub_camps: untergeordnete Lager zulassen
+        super_camp: Übergeordnetes Lager
 
       event/course:
         requires_approval: Empfehlung der Anmeldungen nötig durch

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -195,7 +195,6 @@ de:
       phone_mobil: Telefon Mobil
       email: E-Mail
       attach_to_supercamp: An übergeordnetes Lager anschliessen
-      supercamp: Übergeordnetes Lager
       direct_subcamps: direkt untergeordnete Lager
     form_tab_pane_advisors:
       al_present_caption: Die Abteilungsleitung ist im Lager anwesend

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -220,6 +220,7 @@ de:
     tabs:
       approvals: Empfehlungen
       attendances: Anwesenheit
+      sub_camps: Untergeordnete Lager
     form_actions_caption_pbs:
       lagerreglement_applied_caption: Das Reglement zur Planung und Durchführung von Lagern ("Lagerreglement“) sowie das Pfadiprofil werden berücksichtigt und eingehalten
       kantonalverband_rules_applied_caption: Allenfalls vorhandene Vorschriften oder Empfehlungen des Kantonalverbandes werden bei der Vorbereitung des Lagers berücksichtigt

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -196,6 +196,7 @@ de:
       email: E-Mail
       attach_to_supercamp: An übergeordnetes Lager anschliessen
       supercamp: Übergeordnetes Lager
+      direct_subcamps: direkt untergeordnete Lager
     form_tab_pane_advisors:
       al_present_caption: Die Abteilungsleitung ist im Lager anwesend
       al_visiting_caption: Die Abteilungsleitung besucht das Lager

--- a/db/migrate/20191021173800_upgrade_camps_to_nested_set.rb
+++ b/db/migrate/20191021173800_upgrade_camps_to_nested_set.rb
@@ -1,0 +1,30 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class UpgradeCampsToNestedSet < ActiveRecord::Migration
+  def change
+    nested_set_class = Event
+
+    add_column nested_set_class.table_name, :lft, :integer
+    add_column nested_set_class.table_name, :rgt, :integer
+
+    reversible do |dirs|
+      dirs.up do
+
+        if nested_set_class.respond_to?(:rebuild!)
+          say_with_time %Q[Building the "nested set"-tree/-forest for #{nested_set_class.name}] do
+            nested_set_class.reset_column_information
+            nested_set_class.rebuild!
+          end
+        else
+          say %Q[#{nested_set_class.name} is not defined as "nested set" in ruby]
+        end
+      end
+    end
+
+    add_index nested_set_class.table_name, :lft
+    add_index nested_set_class.table_name, :rgt
+  end
+end

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2018, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012 - 2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -31,6 +31,8 @@ module HitobitoPbs
       Event::Participation.send :include, Pbs::Event::Participation
       Event::ParticipationContactData.send :include, Pbs::Event::ParticipationContactData
       Event::Application.send :include, Pbs::Event::Application
+
+      Event.acts_as_nested_set(dependent: :nullify)
 
       PeopleRelation.kind_opposites['sibling'] = 'sibling'
       PhoneNumber.send :include, Pbs::PhoneNumber


### PR DESCRIPTION
Für das Tab "Untergeordnete Lager" habe ich die reine `parent_id`-Lösung zu einem echten nested_set ausgebaut. Bisher wird nur das Tab angezeigt, es ist noch keine Funktion dahinter. Ich bin erst davon ausgegangen, dass ich schon für dieses Issue das nested_set brauche, tatsächlich ist es aber erst im nächsten notwendig.

In der Darstellung werden das übergeordnete Lager oder die direkten Unterlager verlinkt angezeigt.

See hitobito/hitobito#831