### PR TITLE
Lagerhierarchien: Anmeldeangaben und Kontaktdaten auf untergeordnetem Lager

### DIFF
--- a/app/controllers/pbs/events_controller.rb
+++ b/app/controllers/pbs/events_controller.rb
@@ -20,6 +20,17 @@ module Pbs::EventsController
     alias_method_chain :edit, :assign_attributes
     alias_method_chain :permitted_attrs, :superior_and_coach_check
     alias_method_chain :sort_expression, :canton
+
+    # Merge all hashes in permitted_attrs and move them to the end of the list, so we can more
+    # easily inject new nested attrs
+    self.permitted_attrs = self.permitted_attrs.reduce([[], {}]) do |result, attr|
+      result[0] << attr unless attr.is_a? Hash
+      result[1].merge! attr if attr.is_a? Hash
+      result
+    end.reduce(:<<)
+
+    self.permitted_attrs.last[:application_questions_attributes] << :pass_on_to_supercamp
+    self.permitted_attrs.last[:admin_questions_attributes] << :pass_on_to_supercamp
   end
 
   def edit_with_assign_attributes

--- a/app/controllers/pbs/events_controller.rb
+++ b/app/controllers/pbs/events_controller.rb
@@ -11,14 +11,20 @@ module Pbs::EventsController
   included do
     before_action :remove_restricted, only: [:create, :update]
     before_action :check_checkpoint_attrs, only: [:create, :update]
+    before_action :merge_supercamp_data, only: [:new, :edit]
 
     prepend_before_action :entry, only: [:show_camp_application, :create_camp_application]
-    before_action :merge_supercamp_data, only: [:new, :edit]
 
     before_render_show :load_participation_emails, if: :canceled?
 
+    alias_method_chain :edit, :assign_attributes
     alias_method_chain :permitted_attrs, :superior_and_coach_check
     alias_method_chain :sort_expression, :canton
+  end
+
+  def edit_with_assign_attributes
+    assign_attributes if model_params
+    edit_without_assign_attributes
   end
 
   def sort_expression_with_canton
@@ -109,7 +115,6 @@ module Pbs::EventsController
     return unless flash[:event_with_merged_supercamp]
     params[:event] ||= {}
     params[:event].merge!(flash[:event_with_merged_supercamp])
-    assign_attributes
   end
 
 end

--- a/app/controllers/pbs/events_controller.rb
+++ b/app/controllers/pbs/events_controller.rb
@@ -20,6 +20,7 @@ module Pbs::EventsController
     alias_method_chain :edit, :assign_attributes
     alias_method_chain :permitted_attrs, :superior_and_coach_check
     alias_method_chain :sort_expression, :canton
+    alias_method_chain :assign_contact_attrs, :supercamp_flag
 
     # Merge all hashes in permitted_attrs and move them to the end of the list, so we can more
     # easily inject new nested attrs
@@ -56,6 +57,17 @@ module Pbs::EventsController
   def canton_labels_with_abroad
     Cantons.labels.merge(Event::Camp::ABROAD_CANTON =>
                          Cantons.full_name(Event::Camp::ABROAD_CANTON))
+  end
+
+  def assign_contact_attrs_with_supercamp_flag
+    contact_attrs = assign_contact_attrs_without_supercamp_flag
+
+    supercamp_contact_attrs = model_params.delete(:contact_attrs_passed_on_to_supercamp)
+    return contact_attrs if supercamp_contact_attrs.blank?
+    entry.contact_attrs_passed_on_to_supercamp =
+      supercamp_contact_attrs.reject { |_, v| v == '0' }.keys
+
+    contact_attrs
   end
 
   def show_camp_application

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -5,11 +5,29 @@
 
 class SupercampsController < ApplicationController
   skip_authorization_check
+  before_action :authorize, only: [:connect]
 
   helper_method :group, :camp_id
   decorates :group
 
   respond_to :js
+
+  EXCLUDED_SUPERCAMP_ATTRS = %w(
+    id type name state description
+    expected_participants_wolf_f expected_participants_wolf_m
+    expected_participants_pfadi_f expected_participants_pfadi_m
+    expected_participants_pio_f expected_participants_pio_m
+    expected_participants_rover_f expected_participants_rover_m
+    expected_participants_leitung_f expected_participants_leitung_m
+    parent_id allow_sub_camps group_ids
+    maximum_participants
+    leader abteilungsleitung al_present al_visiting al_visiting_date
+    coach coach_visiting coach_visiting_date
+    advisor_mountain_security advisor_snow_security advisor_water_security
+    lagerreglement_applied kantonalverband_rules_applied j_s_rules_applied
+  ).freeze
+
+  EXCLUDED_DATES_ATTRS = %w(id event_id).freeze
 
   def available
     group
@@ -35,8 +53,25 @@ class SupercampsController < ApplicationController
     @camp_id ||= params[:camp_id]
   end
 
+  def supercamp
+    @supercamp ||= Event.includes(:dates).find(params[:supercamp_id])
+  end
+
+  def dates_attributes
+    supercamp.dates.map { |date| date.attributes.except(*EXCLUDED_DATES_ATTRS) }
+  end
+
+  def supercamp_attrs
+    @supercamp_attrs ||= supercamp.attributes.except(*EXCLUDED_SUPERCAMP_ATTRS)
+                           .merge({ dates_attributes: dates_attributes })
+  end
+
   def event_with_merged_supercamp
-    params[:event].merge({'parent_id' => params[:supercamp_id]})
+    params[:event].merge(supercamp_attrs).merge({'parent_id' => params[:supercamp_id]})
+  end
+
+  def authorize
+    authorize!(:show, supercamp)
   end
 
 end

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -44,7 +44,7 @@ class SupercampsController < ApplicationController
 
   def connect
     flash[:event_with_merged_supercamp] = event_with_merged_supercamp
-    redirect_to request.referer
+    redirect_to :back
   end
 
   private
@@ -84,7 +84,10 @@ class SupercampsController < ApplicationController
   end
 
   def appended_description
-    [params[:event][:description].strip, supercamp.description.strip].join("\n\n").strip
+    [
+      params[:event][:description].to_s.strip,
+      supercamp.description.to_s.strip
+    ].join("\n\n").strip
   end
 
   def event_with_merged_supercamp

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -92,11 +92,27 @@ class SupercampsController < ApplicationController
     end
   end
 
+  def required_contact_attrs
+    all_required_attrs = supercamp.required_contact_attrs +
+      Event::ParticipationContactData.mandatory_contact_attrs
+    all_required_attrs.map do |attr|
+      [attr, :required]
+    end.to_h
+  end
+
+  def supercamp_attributes_to_merge
+    {
+      dates_attributes: dates_attributes,
+      application_questions_attributes: application_questions_attrs,
+      admin_questions_attributes: admin_questions_attrs,
+      contact_attrs: required_contact_attrs,
+      contact_attrs_passed_on_to_supercamp: required_contact_attrs
+    }
+  end
+
   def supercamp_attrs
     @supercamp_attrs ||= supercamp.attributes.except(*EXCLUDED_SUPERCAMP_ATTRS)
-                           .merge(dates_attributes: dates_attributes,
-                                  application_questions_attributes: application_questions_attrs,
-                                  admin_questions_attributes: admin_questions_attrs)
+                                             .merge(supercamp_attributes_to_merge)
   end
 
   def generated_name

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -10,6 +10,7 @@ class SupercampsController < ApplicationController
   helper_method :group, :camp_id
   decorates :group
 
+  rescue_from CanCan::AccessDenied, with: :handle_access_denied
   respond_to :js
 
   EXCLUDED_SUPERCAMP_ATTRS = %w(
@@ -72,6 +73,13 @@ class SupercampsController < ApplicationController
 
   def authorize
     authorize!(:show, supercamp)
+    unless supercamp.state == 'created'
+      raise CanCan::AccessDenied.new(I18n.t('supercamps.not_in_created_state'), :connect, supercamp)
+    end
+  end
+
+  def handle_access_denied(e)
+    redirect_to :back, alert: e.message
   end
 
 end

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -30,6 +30,8 @@ class SupercampsController < ApplicationController
 
   EXCLUDED_DATES_ATTRS = %w(id event_id).freeze
 
+  EXCLUDED_QUESTIONS_ATTRS = %w(id event_id).freeze
+
   def available
     supercamps_on_group_and_above
   end
@@ -70,16 +72,31 @@ class SupercampsController < ApplicationController
   end
 
   def supercamp
-    @supercamp ||= Event.includes(:dates).find(params[:supercamp_id])
+    @supercamp ||= Event.includes(:dates, :application_questions, :admin_questions)
+                     .find(params[:supercamp_id])
   end
 
   def dates_attributes
     supercamp.dates.map { |date| date.attributes.except(*EXCLUDED_DATES_ATTRS) }
   end
 
+  def application_questions_attrs
+    supercamp.application_questions.map do |question|
+      question.attributes.except(*EXCLUDED_QUESTIONS_ATTRS).merge(pass_on_to_supercamp: true)
+    end
+  end
+
+  def admin_questions_attrs
+    supercamp.admin_questions.map do |question|
+      question.attributes.except(*EXCLUDED_QUESTIONS_ATTRS).merge(pass_on_to_supercamp: true)
+    end
+  end
+
   def supercamp_attrs
     @supercamp_attrs ||= supercamp.attributes.except(*EXCLUDED_SUPERCAMP_ATTRS)
-                           .merge({ dates_attributes: dates_attributes })
+                           .merge(dates_attributes: dates_attributes,
+                                  application_questions_attributes: application_questions_attrs,
+                                  admin_questions_attributes: admin_questions_attrs)
   end
 
   def generated_name

--- a/app/controllers/supercamps_controller.rb
+++ b/app/controllers/supercamps_controller.rb
@@ -14,7 +14,7 @@ class SupercampsController < ApplicationController
   respond_to :js
 
   EXCLUDED_SUPERCAMP_ATTRS = %w(
-    id type name state description
+    id type name state
     expected_participants_wolf_f expected_participants_wolf_m
     expected_participants_pfadi_f expected_participants_pfadi_m
     expected_participants_pio_f expected_participants_pio_m
@@ -67,8 +67,20 @@ class SupercampsController < ApplicationController
                            .merge({ dates_attributes: dates_attributes })
   end
 
+  def generated_name
+    supercamp.name + ': ' + group.display_name
+  end
+
+  def appended_description
+    [params[:event][:description].strip, supercamp.description.strip].join("\n\n")
+  end
+
   def event_with_merged_supercamp
-    params[:event].merge(supercamp_attrs).merge({'parent_id' => params[:supercamp_id]})
+    params[:event]
+      .merge(supercamp_attrs)
+      .merge(parent_id: params[:supercamp_id],
+             name: generated_name,
+             description: appended_description)
   end
 
   def authorize

--- a/app/decorators/pbs/group_decorator.rb
+++ b/app/decorators/pbs/group_decorator.rb
@@ -8,12 +8,12 @@
 module Pbs::GroupDecorator
   extend ActiveSupport::Concern
 
-  def supercamps(exclude_id = nil)
-    events.where(allow_sub_camps: true, state: 'created').where.not(id: exclude_id)
+  def supercamps
+    events.where(allow_sub_camps: true, state: 'created')
   end
 
-  def supercamps_on_group_and_above(exclude_id = nil)
-    supercamps(exclude_id) + (root? ? [] : parent.supercamps_on_group_and_above(exclude_id))
+  def supercamps_on_group_and_above
+    supercamps + (root? ? [] : parent.supercamps_on_group_and_above)
   end
 
 end

--- a/app/decorators/pbs/group_decorator.rb
+++ b/app/decorators/pbs/group_decorator.rb
@@ -9,7 +9,7 @@ module Pbs::GroupDecorator
   extend ActiveSupport::Concern
 
   def supercamps(exclude_id = nil)
-    events.where(allow_sub_camps: true).where.not(id: exclude_id)
+    events.where(allow_sub_camps: true, state: 'created').where.not(id: exclude_id)
   end
 
   def supercamps_on_group_and_above(exclude_id = nil)

--- a/app/helpers/pbs/contact_attrs/control_builder.rb
+++ b/app/helpers/pbs/contact_attrs/control_builder.rb
@@ -13,6 +13,8 @@ module Pbs
 
       included do
         alias_method_chain :initialize, :required_contact_attrs
+        alias_method_chain :radio_buttons, :supercamp_flag
+        alias_method_chain :assoc_checkbox, :supercamp_flag
       end
 
       def initialize_with_required_contact_attrs(form, event)
@@ -22,6 +24,33 @@ module Pbs
         @event.event.required_contact_attrs += %w(address zip_code town country gender birthday
                                                   nationality_j_s ahv_number
                                                   correspondence_language)
+      end
+
+      def radio_buttons_with_supercamp_flag(*args)
+        radio_buttons_without_supercamp_flag(*args) +
+          pass_on_to_supercamp_checkbox(args[0])
+      end
+
+      def assoc_checkbox_with_supercamp_flag(*args)
+        assoc_checkbox_without_supercamp_flag(*args) +
+          pass_on_to_supercamp_checkbox(args[0])
+      end
+
+      def pass_on_to_supercamp_checkbox(attr)
+        return '' unless @event.event.parent_id
+
+        f.label(supercamp_label(attr), class: 'checkbox inline') do
+          options = { checked: attr_passed_on_to_supercamp?(attr) }
+          f.check_box(supercamp_label(attr), options) + option_label(:pass_on_to_supercamp)
+        end
+      end
+
+      def supercamp_label(attr)
+        "contact_attrs_passed_on_to_supercamp[#{attr}]"
+      end
+
+      def attr_passed_on_to_supercamp?(attr)
+        event.contact_attrs_passed_on_to_supercamp.include?(attr.to_s)
       end
     end
   end

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -135,6 +135,9 @@ class Event::Camp < Event
            inverse_of: :super_camp,
            dependent: :restrict_with_error
 
+  ### SERIALIZED ATTRIBUTES
+  serialize :contact_attrs_passed_on_to_supercamp, Array
+
   ### VALIDATIONS
 
   validates :state, inclusion: possible_states
@@ -148,9 +151,6 @@ class Event::Camp < Event
   after_save :send_assignment_infos
   after_save :send_abteilungsleitung_assignment_info
   after_save :send_created_infos
-
-  ### SERIALIZED ATTRIBUTES
-  serialize :contact_attrs_passed_on_to_supercamp, Array
 
   ### INSTANCE METHODS
 

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -9,87 +9,88 @@
 #
 # Table name: events
 #
-#  id                                :integer          not null, primary key
-#  type                              :string(255)
-#  name                              :string(255)      not null
-#  number                            :string(255)
-#  motto                             :string(255)
-#  cost                              :string(255)
-#  maximum_participants              :integer
-#  contact_id                        :integer
-#  description                       :text(65535)
-#  location                          :text(65535)
-#  application_opening_at            :date
-#  application_closing_at            :date
-#  application_conditions            :text(65535)
-#  kind_id                           :integer
-#  state                             :string(60)
-#  priorization                      :boolean          default(FALSE), not null
-#  requires_approval                 :boolean          default(FALSE), not null
-#  created_at                        :datetime
-#  updated_at                        :datetime
-#  participant_count                 :integer          default(0)
-#  application_contact_id            :integer
-#  external_applications             :boolean          default(FALSE)
-#  applicant_count                   :integer          default(0)
-#  teamer_count                      :integer          default(0)
-#  signature                         :boolean
-#  signature_confirmation            :boolean
-#  signature_confirmation_text       :string(255)
-#  creator_id                        :integer
-#  updater_id                        :integer
-#  applications_cancelable           :boolean          default(FALSE), not null
-#  training_days                     :decimal(12, 1)
-#  tentative_applications            :boolean          default(FALSE), not null
-#  language_de                       :boolean          default(FALSE), not null
-#  language_fr                       :boolean          default(FALSE), not null
-#  language_it                       :boolean          default(FALSE), not null
-#  language_en                       :boolean          default(FALSE), not null
-#  express_fee                       :string
-#  requires_approval_abteilung       :boolean          default(FALSE), not null
-#  requires_approval_region          :boolean          default(FALSE), not null
-#  requires_approval_kantonalverband :boolean          default(FALSE), not null
-#  requires_approval_bund            :boolean          default(FALSE), not null
-#  expected_participants_wolf_f      :integer
-#  expected_participants_wolf_m      :integer
-#  expected_participants_pfadi_f     :integer
-#  expected_participants_pfadi_m     :integer
-#  expected_participants_pio_f       :integer
-#  expected_participants_pio_m       :integer
-#  expected_participants_rover_f     :integer
-#  expected_participants_rover_m     :integer
-#  expected_participants_leitung_f   :integer
-#  expected_participants_leitung_m   :integer
-#  canton                            :string(2)
-#  coordinates                       :string
-#  altitude                          :string
-#  emergency_phone                   :string
-#  landlord                          :text
-#  landlord_permission_obtained      :boolean          default(FALSE), not null
-#  j_s_kind                          :string
-#  j_s_security_snow                 :boolean          default(FALSE), not null
-#  j_s_security_mountain             :boolean          default(FALSE), not null
-#  j_s_security_water                :boolean          default(FALSE), not null
-#  participants_can_apply            :boolean          default(FALSE), not null
-#  participants_can_cancel           :boolean          default(FALSE), not null
-#  al_present                        :boolean          default(FALSE), not null
-#  al_visiting                       :boolean          default(FALSE), not null
-#  al_visiting_date                  :date
-#  coach_visiting                    :boolean          default(FALSE), not null
-#  coach_visiting_date               :date
-#  coach_confirmed                   :boolean          default(FALSE), not null
-#  local_scout_contact_present       :boolean          default(FALSE), not null
-#  local_scout_contact               :text
-#  camp_submitted                    :boolean          default(FALSE), not null
-#  camp_reminder_sent                :boolean          default(FALSE), not null
-#  paper_application_required        :boolean          default(FALSE), not null
-#  lagerreglement_applied            :boolean          default(FALSE), not null
-#  kantonalverband_rules_applied     :boolean          default(FALSE), not null
-#  j_s_rules_applied                 :boolean          default(FALSE), not null
-#  required_contact_attrs            :text
-#  hidden_contact_attrs              :text
-#  display_booking_info              :boolean          default(TRUE), not null
-#  bsv_days                          :decimal(6, 2)
+#  id                                   :integer          not null, primary key
+#  type                                 :string(255)
+#  name                                 :string(255)      not null
+#  number                               :string(255)
+#  motto                                :string(255)
+#  cost                                 :string(255)
+#  maximum_participants                 :integer
+#  contact_id                           :integer
+#  description                          :text(65535)
+#  location                             :text(65535)
+#  application_opening_at               :date
+#  application_closing_at               :date
+#  application_conditions               :text(65535)
+#  kind_id                              :integer
+#  state                                :string(60)
+#  priorization                         :boolean          default(FALSE), not null
+#  requires_approval                    :boolean          default(FALSE), not null
+#  created_at                           :datetime
+#  updated_at                           :datetime
+#  participant_count                    :integer          default(0)
+#  application_contact_id               :integer
+#  external_applications                :boolean          default(FALSE)
+#  applicant_count                      :integer          default(0)
+#  teamer_count                         :integer          default(0)
+#  signature                            :boolean
+#  signature_confirmation               :boolean
+#  signature_confirmation_text          :string(255)
+#  creator_id                           :integer
+#  updater_id                           :integer
+#  applications_cancelable              :boolean          default(FALSE), not null
+#  training_days                        :decimal(12, 1)
+#  tentative_applications               :boolean          default(FALSE), not null
+#  language_de                          :boolean          default(FALSE), not null
+#  language_fr                          :boolean          default(FALSE), not null
+#  language_it                          :boolean          default(FALSE), not null
+#  language_en                          :boolean          default(FALSE), not null
+#  express_fee                          :string
+#  requires_approval_abteilung          :boolean          default(FALSE), not null
+#  requires_approval_region             :boolean          default(FALSE), not null
+#  requires_approval_kantonalverband    :boolean          default(FALSE), not null
+#  requires_approval_bund               :boolean          default(FALSE), not null
+#  expected_participants_wolf_f         :integer
+#  expected_participants_wolf_m         :integer
+#  expected_participants_pfadi_f        :integer
+#  expected_participants_pfadi_m        :integer
+#  expected_participants_pio_f          :integer
+#  expected_participants_pio_m          :integer
+#  expected_participants_rover_f        :integer
+#  expected_participants_rover_m        :integer
+#  expected_participants_leitung_f      :integer
+#  expected_participants_leitung_m      :integer
+#  canton                               :string(2)
+#  coordinates                          :string
+#  altitude                             :string
+#  emergency_phone                      :string
+#  landlord                             :text
+#  landlord_permission_obtained         :boolean          default(FALSE), not null
+#  j_s_kind                             :string
+#  j_s_security_snow                    :boolean          default(FALSE), not null
+#  j_s_security_mountain                :boolean          default(FALSE), not null
+#  j_s_security_water                   :boolean          default(FALSE), not null
+#  participants_can_apply               :boolean          default(FALSE), not null
+#  participants_can_cancel              :boolean          default(FALSE), not null
+#  al_present                           :boolean          default(FALSE), not null
+#  al_visiting                          :boolean          default(FALSE), not null
+#  al_visiting_date                     :date
+#  coach_visiting                       :boolean          default(FALSE), not null
+#  coach_visiting_date                  :date
+#  coach_confirmed                      :boolean          default(FALSE), not null
+#  local_scout_contact_present          :boolean          default(FALSE), not null
+#  local_scout_contact                  :text
+#  camp_submitted                       :boolean          default(FALSE), not null
+#  camp_reminder_sent                   :boolean          default(FALSE), not null
+#  paper_application_required           :boolean          default(FALSE), not null
+#  lagerreglement_applied               :boolean          default(FALSE), not null
+#  kantonalverband_rules_applied        :boolean          default(FALSE), not null
+#  j_s_rules_applied                    :boolean          default(FALSE), not null
+#  required_contact_attrs               :text(65535)
+#  hidden_contact_attrs                 :text(65535)
+#  contact_attrs_passed_on_to_supercamp :text(65535)
+#  display_booking_info                 :boolean          default(TRUE), not null
+#  bsv_days                             :decimal(6, 2)
 #
 
 class Event::Camp < Event
@@ -102,7 +103,7 @@ class Event::Camp < Event
 
   self.used_attributes += [
     :state, :group_ids, :participants_can_apply, :participants_can_cancel,
-    :parent_id, :allow_sub_camps
+    :parent_id, :allow_sub_camps, :contact_attrs_passed_on_to_supercamp
   ]
 
   self.used_attributes -= [:contact_id, :applications_cancelable]
@@ -137,6 +138,7 @@ class Event::Camp < Event
   validates :state, inclusion: possible_states
   validate :may_become_sub_camp, if: :parent_id_changed?
   validates :allow_sub_camps, acceptance: { accept: true }, if: 'sub_camps.any?'
+  validate :assert_contact_attrs_passed_on_to_supercamp_valid, if: :parent_id
 
   ### CALLBACKS
 
@@ -145,6 +147,8 @@ class Event::Camp < Event
   after_save :send_abteilungsleitung_assignment_info
   after_save :send_created_infos
 
+  ### SERIALIZED ATTRIBUTES
+  serialize :contact_attrs_passed_on_to_supercamp, Array
 
   ### INSTANCE METHODS
 
@@ -259,6 +263,17 @@ class Event::Camp < Event
   def may_become_sub_camp
     if super_camp.present? && (!super_camp.allow_sub_camps || super_camp.state != 'created')
       errors.add(:parent_id, :invalid)
+    end
+  end
+
+  def assert_contact_attrs_passed_on_to_supercamp_valid
+    contact_attrs_passed_on_to_supercamp.map(&:to_s).each do |a|
+      unless valid_contact_attr?(a)
+        errors.add(:base, :contact_attr_invalid, attribute: a)
+      end
+      if hidden_contact_attrs.include?(a)
+        errors.add(:base, :contact_attr_passed_on_to_supercamp_hidden, attribute: a)
+      end
     end
   end
 

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -257,7 +257,7 @@ class Event::Camp < Event
   end
 
   def may_become_sub_camp
-    if super_camp.present? && (!super_camp.allow_sub_camps || super_camp.state == 'created')
+    if super_camp.present? && (!super_camp.allow_sub_camps || super_camp.state != 'created')
       errors.add(:parent_id, :invalid)
     end
   end

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -257,7 +257,7 @@ class Event::Camp < Event
   end
 
   def may_become_sub_camp
-    if super_camp.present? && !super_camp.allow_sub_camps
+    if super_camp.present? && (!super_camp.allow_sub_camps || super_camp.state == 'created')
       errors.add(:parent_id, :invalid)
     end
   end

--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -136,7 +136,7 @@ class Event::Camp < Event
 
   validates :state, inclusion: possible_states
   validate :may_become_sub_camp, if: :parent_id_changed?
-  validates :allow_sub_camps, acceptance: true, if: 'sub_camps.any?'
+  validates :allow_sub_camps, acceptance: { accept: true }, if: 'sub_camps.any?'
 
   ### CALLBACKS
 

--- a/app/views/event/questions/_fields_subcamp.html.haml
+++ b/app/views/event/questions/_fields_subcamp.html.haml
@@ -1,0 +1,8 @@
+-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+-#  hitobito_pbs and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_pbs.
+
+
+- if f.options[:parent_builder].object.super_camp
+  = f.labeled_input_field(:pass_on_to_supercamp)

--- a/app/views/supercamps/_available.html.haml
+++ b/app/views/supercamps/_available.html.haml
@@ -8,14 +8,16 @@
 
         - if @supercamps_on_group_and_above.count > 0
           = field_set_tag t('.from_group_and_above') do
-            - @supercamps_on_group_and_above.each do |supercamp|
-              = label_tag('supercamp_' + supercamp.id.to_s) do
-                = radio_button_tag(:supercamp,
-                                   group_connect_supercamp_path(supercamp_id: supercamp.id,
-                                                                camp_id: camp_id),
-                                   false,
-                                   "id" => 'supercamp_' + supercamp.id.to_s)
-                = format_camp_name_with_groups(supercamp)
+            = render 'selectable_supercamps',
+                     options: @supercamps_on_group_and_above, prefix: :above
+
+        = field_set_tag t('.search_for_supercamp'), id: :supercamp_search do
+          = form_tag group_query_supercamps_path, method: :get, remote: true do
+            = hidden_field :selected_supercamp, :id
+            = text_field :selected_supercamp, :q, name: :q
+            .btn-group
+              = button_tag t('.search'), class: 'btn btn-secondary'
+          #supercamp-search-results
 
       .modal-footer
         .btn-group
@@ -23,4 +25,3 @@
         = link_to(ti('button.cancel'), '#',
           class: 'link cancel',
           onclick: "event.preventDefault(); $('#supercamps-available').modal('hide')")
-

--- a/app/views/supercamps/_selectable_supercamps.html.haml
+++ b/app/views/supercamps/_selectable_supercamps.html.haml
@@ -1,0 +1,12 @@
+- if options.empty?
+  = t('.none')
+- else
+  - options.each do |supercamp|
+    - id = prefix.to_s + '_supercamp_' + supercamp.id.to_s
+    = label_tag(id) do
+      = radio_button_tag(:supercamp,
+                         group_connect_supercamp_path(supercamp_id: supercamp.id,
+                                                      camp_id: camp_id),
+                         false,
+                         "id" => id)
+      = format_camp_name_with_groups(supercamp)

--- a/app/views/supercamps/available.js.haml
+++ b/app/views/supercamps/available.js.haml
@@ -1,4 +1,4 @@
-$('#modal-placeholder').html("#{escape_javascript(render(partial: 'supercamps/available'))}")
+$('#modal-placeholder').html("#{escape_javascript(render 'available')}")
 
 :plain
   $('#supercamps-available-submit').click(function() {

--- a/app/views/supercamps/query.js.haml
+++ b/app/views/supercamps/query.js.haml
@@ -1,0 +1,1 @@
+$('#supercamp-search-results').html("#{escape_javascript(render('selectable_supercamps', options: @found_supercamps, prefix: :found))}")

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1071,6 +1071,9 @@ de:
       event/participation:
         bsv_days: BSV-Tage
 
+      event/question:
+        pass_on_to_supercamp: An übergeordnetes Lager weitergeben
+
       person:
         layer_group_id: Id der Hauptebene
         nickname: Pfadiname

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1055,6 +1055,9 @@ de:
         leader_unassigned: Keine Leitenden erfasst
         allow_sub_camps: untergeordnete Lager zulassen
 
+      event/contact_attrs:
+        pass_on_to_supercamp: An übergeordnetes Lager weitergeben
+
       event/course:
         requires_approval: Empfehlung der Anmeldungen nötig durch
         advisor: LKB
@@ -1161,6 +1164,10 @@ de:
         must_be_multiple_of: muss ein vielfaches von %{multiple} sein.
         must_be_valid_social_security_number: muss eine gültige AHV-Nummer (756.1234.5678.97) sein
       models:
+        event:
+          attributes:
+            base:
+              contact_attr_passed_on_to_supercamp_hidden: "'%{attribute}' muss entweder angezeigt oder nicht ans übergeordnete Lager weitergegeben werden"
         role:
           attributes:
             created_at:

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -325,7 +325,11 @@ de:
     available:
       select_supercamp: Übergeordnetes Lager auswählen
       from_group_and_above: Auf dieser Gruppe und darüber
+      search_for_supercamp: Anderes übergeordnetes Lager suchen
+      search: Suchen
       submit: Bestätigen
+    selectable_supercamps:
+      none: Keine Ergebnisse gefunden
     not_in_created_state: Das gewählte übergeordnete Lager ist nicht im Status "Erstellt"
 
   black_lists:

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -326,6 +326,7 @@ de:
       select_supercamp: Übergeordnetes Lager auswählen
       from_group_and_above: Auf dieser Gruppe und darüber
       submit: Bestätigen
+    not_in_created_state: Das gewählte übergeordnete Lager ist nicht im Status "Erstellt"
 
   black_lists:
     form:

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -330,6 +330,7 @@ de:
       submit: Bestätigen
     selectable_supercamps:
       none: Keine Ergebnisse gefunden
+    does_not_allow_sub_camps: Das gewählte Lager erlaubt keine untergeordneten Lager
     not_in_created_state: Das gewählte übergeordnete Lager ist nicht im Status "Erstellt"
 
   black_lists:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       end
 
       get 'supercamps' => 'supercamps#available'
+      get 'query_supercamps' => 'supercamps#query'
       post 'connect_supercamp' => 'supercamps#connect'
       patch 'connect_supercamp' => 'supercamps#connect'
 

--- a/db/migrate/20191021155100_add_subcamp_field_to_questions.rb
+++ b/db/migrate/20191021155100_add_subcamp_field_to_questions.rb
@@ -1,0 +1,14 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class AddSubcampFieldToQuestions < ActiveRecord::Migration
+  def up
+    add_column :event_questions, :pass_on_to_supercamp, :boolean, null: false, default: false
+  end
+
+  def down
+    remove_column :event_questions, :pass_on_to_supercamp
+  end
+end

--- a/db/migrate/20191028135000_add_contact_attrs_passed_on_to_supercamp_to_events.rb
+++ b/db/migrate/20191028135000_add_contact_attrs_passed_on_to_supercamp_to_events.rb
@@ -6,6 +6,10 @@
 class AddContactAttrsPassedOnToSupercampToEvents < ActiveRecord::Migration
   def up
     add_column :events, :contact_attrs_passed_on_to_supercamp, :text, limit: 65535
+
+    Event.reset_column_information
+    Event::Course.reset_column_information
+    Event::Camp.reset_column_information
   end
 
   def down

--- a/db/migrate/20191028135000_add_contact_attrs_passed_on_to_supercamp_to_events.rb
+++ b/db/migrate/20191028135000_add_contact_attrs_passed_on_to_supercamp_to_events.rb
@@ -1,0 +1,14 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class AddContactAttrsPassedOnToSupercampToEvents < ActiveRecord::Migration
+  def up
+    add_column :events, :contact_attrs_passed_on_to_supercamp, :text, limit: 65535
+  end
+
+  def down
+    remove_column :events, :contact_attrs_passed_on_to_supercamp
+  end
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -147,6 +147,18 @@ describe EventsController do
         expect(event.reload).to be_camp_submitted
       end
 
+      it 'can still submit camp when adding a supercamp' do
+        group = event.groups.first
+        event.update!(required_attrs_for_camp_submit)
+        event.update_attributes(parent_id: events(:bund_supercamp).id)
+
+        put :create_camp_application, group_id: group.id, id: event.id
+        expect(response).to redirect_to(group_event_path(group, event))
+        expect(event.reload.camp_submitted_at).to eq Date.today
+        expect(flash[:notice]).to match /eingereicht/
+        expect(event.reload).to be_camp_submitted
+      end
+
       context 'for campy course' do
         let(:event) { Fabricate(:course, kind: event_kinds(:fut)) }
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -266,4 +266,38 @@ describe EventsController do
       values
     end
   end
+
+  context 'merging data from selected supercamp' do
+
+    let(:camp) { events(:schekka_camp) }
+    let(:course) { events(:top_course) }
+    let(:campy_course) { Fabricate(:course, kind: event_kinds(:fut)) }
+    let(:event) { events(:top_event) }
+    let(:entry) { controller.send(:entry) }
+    before do
+      sign_in(people(:bulei))
+      allow(controller).to receive(:flash).and_return(event_with_merged_supercamp: {
+        name: 'Hierarchisches Lager: Schekka',
+        dates_attributes: [{ location: 'Linth-Ebene' }]
+      })
+    end
+
+    it 'merges data from flash for camp' do
+      get :edit, group_id: camp.groups.first.id, id: camp.id
+      expect(entry.name).to eq('Hierarchisches Lager: Schekka')
+      expect(entry.dates.map(&:location)).to include('Linth-Ebene')
+    end
+
+    [:course, :campy_course, :event].each do |event_type|
+
+      it 'does not merge for ' + event_type.to_s do
+        e = send(event_type)
+        get :edit, group_id: e.groups.first.id, id: e.id
+        expect(entry.name).not_to eq('Hierarchisches Lager: Schekka')
+        expect(entry.dates.map(&:location)).not_to include('Linth-Ebene')
+      end
+
+    end
+
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -150,7 +150,7 @@ describe EventsController do
       it 'can still submit camp when adding a supercamp' do
         group = event.groups.first
         event.update!(required_attrs_for_camp_submit)
-        event.update_attributes(parent_id: events(:bund_supercamp).id)
+        event.move_to_child_of(events(:bund_supercamp))
 
         put :create_camp_application, group_id: group.id, id: event.id
         expect(response).to redirect_to(group_event_path(group, event))
@@ -318,9 +318,7 @@ describe EventsController do
     let(:group) { event.groups.first }
     let!(:q1) { Fabricate(:question, id: 1, event: event, pass_on_to_supercamp: false) }
     let!(:q2) { Fabricate(:question, id: 2, event: event, admin: true, pass_on_to_supercamp: false) }
-    before do
-      sign_in(people(:al_schekka))
-    end
+    before { sign_in(people(:al_schekka)) }
 
     {application_questions: 1, admin_questions: 2}.each do |attr, qid|
       it attr do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -312,4 +312,23 @@ describe EventsController do
     end
 
   end
+
+  context 'update the pass_on_to_supercamp flag on questions' do
+    let(:event) { events(:schekka_camp) }
+    let(:group) { event.groups.first }
+    let!(:q1) { Fabricate(:question, id: 1, event: event, pass_on_to_supercamp: false) }
+    let!(:q2) { Fabricate(:question, id: 2, event: event, admin: true, pass_on_to_supercamp: false) }
+    before do
+      sign_in(people(:al_schekka))
+    end
+
+    {application_questions: 1, admin_questions: 2}.each do |attr, qid|
+      it attr do
+        put :update, group_id: group.id, id: event.id, event: {
+          (attr.to_s + '_attributes') => [ { id: qid, pass_on_to_supercamp: true } ]
+        }
+        expect(event.reload.send(attr)[0].pass_on_to_supercamp).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -329,4 +329,40 @@ describe EventsController do
       end
     end
   end
+
+  context 'mark contact attributes to be passed on to supercamp' do
+
+    let(:event) { events(:schekka_camp) }
+    let(:group) { event.groups.first }
+
+    before { sign_in(people(:al_schekka)) }
+
+    it 'assigns contact_attributes_passed_on_to_supercamp' do
+
+      put :update, group_id: group.id, id: event.id,
+          event: { contact_attrs_passed_on_to_supercamp: {
+            first_name: '1', nickname: '1', address: '1', social_accounts: '1' } }
+
+      expect(event.reload.contact_attrs_passed_on_to_supercamp).to include('first_name')
+      expect(event.contact_attrs_passed_on_to_supercamp).to include('nickname')
+      expect(event.contact_attrs_passed_on_to_supercamp).to include('address')
+      expect(event.contact_attrs_passed_on_to_supercamp).to include('social_accounts')
+
+    end
+
+    it 'removes contact_attributes_passed_on_to_supercamp' do
+
+      event.update!({ contact_attrs_passed_on_to_supercamp:
+                        ['first_name', 'social_accounts', 'address', 'nickname']})
+
+      put :update, group_id: group.id, id: event.id,
+          event: { contact_attrs_passed_on_to_supercamp: { nickname: '1' } }
+
+      expect(event.reload.contact_attrs_passed_on_to_supercamp).not_to include('first_name')
+      expect(event.contact_attrs_passed_on_to_supercamp).to include('nickname')
+      expect(event.contact_attrs_passed_on_to_supercamp).not_to include('address')
+      expect(event.contact_attrs_passed_on_to_supercamp).not_to include('social_accounts')
+
+    end
+  end
 end

--- a/spec/controllers/supercamps_controller_spec.rb
+++ b/spec/controllers/supercamps_controller_spec.rb
@@ -1,0 +1,94 @@
+#  Copyright (c) 2019 Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe SupercampsController do
+
+  describe 'supercamps available on group and above' do
+    it 'finds supercamps on group and above' do
+
+    end
+  end
+
+  describe 'query possible supercamps' do
+
+  end
+
+  describe 'inherit supercamp data' do
+    before do
+      sign_in(people(:al_schekka))
+      request.env['HTTP_REFERER'] = '/'
+      post :connect, group_id: group.id, supercamp_id: supercamp.id, event: event_form_data
+    end
+
+    let!(:supercamp_dates) { event_dates(:sixth, :sixth_two) }
+    let(:supercamp) { events(:bund_supercamp) }
+    let(:camp) do
+      events(:schekka_camp).tap do |c|
+        c.update(al_visiting: true,
+                 kantonalverband_rules_applied: true,
+                 lagerreglement_applied: true,
+                 coach_visiting: true,
+                 j_s_rules_applied: true,
+                 al_present: true)
+      end
+    end
+    let(:event_form_data) { camp.attributes }
+    let(:group) { camp.groups.first }
+    let(:result) { flash[:event_with_merged_supercamp] }
+
+    it 'authorizes request' do
+      # TODO
+    end
+
+    it 'redirects back' do
+      # TODO
+    end
+
+    it 'name is calculated' do
+      expect(result[:name]).to eq(supercamp.name + ': ' + group.display_name)
+    end
+
+    it 'description is calculated' do
+      expect(result[:description]).to eq((supercamp.description.to_s + "\n\n" + camp.description.to_s).strip)
+    end
+
+    it 'parent_id is correct' do
+      expect(result[:parent_id]).to eq(supercamp.id.to_s)
+    end
+
+    it 'dates from supercamp' do
+      attrs = %w[label location start_at finish_at]
+      expect(result[:dates_attributes].map { |d| d.slice(attrs) })
+        .to eq(supercamp.dates.map { |d| d.attributes.slice(attrs) })
+    end
+
+    [
+      :state, :lagerreglement_applied, :kantonalverband_rules_applied, :j_s_rules_applied,
+      :leader_id, :abteilungsleitung_id, :al_present, :al_visiting, :al_visiting_date, :coach_id,
+      :coach_visiting, :coach_visiting_date, :advisor_mountain_security, :advisor_snow_security,
+      :advisor_water_security
+    ].each do |attr|
+      it attr.to_s + ' from subcamp' do
+        expect(result[attr]).to eq(camp.attributes[attr.to_s])
+      end
+    end
+
+    [
+      :motto, :cost, :location, :canton, :coordinates, :altitude, :emergency_phone, :landlord,
+      :landlord_permission_obtained, :local_scout_contact_present, :local_scout_contact,
+      :j_s_kind, :j_s_security_mountain, :j_s_security_snow, :j_s_security_water,
+      :application_opening_at, :application_closing_at, :application_conditions, :maximum,
+      :external_applications, :signature, :signature_confirmation, :signature_confirmation_text,
+      :paper_application_required, :participants_can_apply, :participants_can_cancel
+    ].each do |attr|
+      it attr.to_s + ' from supercamp' do
+        expect(result[attr]).to eq(supercamp.attributes[attr.to_s])
+      end
+    end
+
+  end
+end

--- a/spec/controllers/supercamps_controller_spec.rb
+++ b/spec/controllers/supercamps_controller_spec.rb
@@ -8,6 +8,8 @@ require 'spec_helper'
 describe SupercampsController do
 
   let!(:supercamp_dates) { event_dates(:sixth, :sixth_two) }
+  let!(:supercamp_application_questions) { Fabricate(:question, event: supercamp) }
+  let!(:supercamp_admin_questions) { Fabricate(:question, admin: true, event: supercamp) }
   let!(:supercamp) { events(:bund_supercamp) }
 
   before do
@@ -139,6 +141,26 @@ describe SupercampsController do
             attrs = %w(label location start_at finish_at)
             expect(result[:dates_attributes].map { |d| d.slice(attrs) })
               .to eq(supercamp.dates.map { |d| d.attributes.slice(attrs) })
+          end
+
+          it 'application questions from supercamp' do
+            attrs = %w(question choices multiple_choices required)
+            expect(result[:application_questions_attributes].map { |q| q.slice(attrs) })
+              .to eq(supercamp.application_questions.map { |q| q.attributes.slice(attrs) })
+          end
+
+          it 'application questions have flag set' do
+            expect(result[:application_questions_attributes][0][:pass_on_to_supercamp]).to be_truthy
+          end
+
+          it 'admin questions from supercamp' do
+            attrs = %w(question choices multiple_choices required)
+            expect(result[:admin_questions_attributes].map { |q| q.slice(attrs) })
+              .to eq(supercamp.admin_questions.map { |q| q.attributes.slice(attrs) })
+          end
+
+          it 'admin questions have flag set' do
+            expect(result[:admin_questions_attributes][0][:pass_on_to_supercamp]).to be_truthy
           end
 
           [

--- a/spec/controllers/supercamps_controller_spec.rb
+++ b/spec/controllers/supercamps_controller_spec.rb
@@ -81,17 +81,22 @@ describe SupercampsController do
         let(:supercamp_allows_sub_camps) { true }
         let(:supercamp_state) { 'created' }
         let(:event_form_data) { camp.attributes }
+        let(:expected_required_contact_attrs) { {'email' => :required,
+                                                 'first_name' => :required,
+                                                 'last_name' => :required,
+                                                 'town' => :required } }
         let(:result) { flash[:event_with_merged_supercamp] }
 
         before do
-          camp.update(al_visiting: true,
-                      kantonalverband_rules_applied: true,
-                      lagerreglement_applied: true,
-                      coach_visiting: true,
-                      j_s_rules_applied: true,
-                      al_present: true)
-          supercamp.update(allow_sub_camps: supercamp_allows_sub_camps,
-                           state: supercamp_state)
+          camp.update!(al_visiting: true,
+                       kantonalverband_rules_applied: true,
+                       lagerreglement_applied: true,
+                       coach_visiting: true,
+                       j_s_rules_applied: true,
+                       al_present: true)
+          supercamp.update!(allow_sub_camps: supercamp_allows_sub_camps,
+                            state: supercamp_state,
+                            required_contact_attrs: [:town])
 
           request.env['HTTP_REFERER'] = '/' + form.to_s
           if form == :create
@@ -161,6 +166,14 @@ describe SupercampsController do
 
           it 'admin questions have flag set' do
             expect(result[:admin_questions_attributes][0][:pass_on_to_supercamp]).to be_truthy
+          end
+
+          it 'required_contact_attrs from supercamp' do
+            expect(result[:contact_attrs]).to eq(expected_required_contact_attrs)
+          end
+
+          it 'contact_attrs_passed_on_to_supercamp from supercamp\'s required_contact attrs' do
+            expect(result[:contact_attrs_passed_on_to_supercamp]).to eq(expected_required_contact_attrs)
           end
 
           [

--- a/spec/controllers/supercamps_controller_spec.rb
+++ b/spec/controllers/supercamps_controller_spec.rb
@@ -7,27 +7,90 @@ require 'spec_helper'
 
 describe SupercampsController do
 
-  describe 'supercamps available on group and above' do
-    it 'finds supercamps on group and above' do
+  let!(:supercamp_dates) { event_dates(:sixth, :sixth_two) }
+  let!(:supercamp) { events(:bund_supercamp) }
 
-    end
+  before do
+    sign_in(people(:al_schekka))
   end
 
-  describe 'query possible supercamps' do
+  describe 'find available supercamps' do
+    let!(:supercamp_schekka) do
+      Fabricate(:event, type: Event::Camp.name, name: 'Schekka Super',
+                        groups: [groups(:schekka)], allow_sub_camps: true, state: 'created')
+    end
+    let!(:supercamp_tsueri) do
+      Fabricate(:event, type: Event::Camp.name, name: 'Tsueri Super', groups: [groups(:chaeib)],
+                        allow_sub_camps: true, state: 'created')
+    end
+    let(:camp) { events(:schekka_camp) }
+    let(:group) { camp.groups.first }
+
+    before do
+      camp.update(allow_sub_camps: true, state: 'created')
+    end
+
+    context 'available' do
+      let(:subject) { assigns(:supercamps_on_group_and_above).map(&:name) }
+
+      it 'available finds supercamps on group and above' do
+        xhr :get, :available, group_id: group.id, camp_id: camp.id, format: :js
+        is_expected.to include('Hauptlager', 'Schekka Super')
+        is_expected.not_to include('Tsueri Super')
+      end
+
+      it 'available excludes itself' do
+        xhr :get, :available, group_id: group.id, camp_id: camp.id, format: :js
+        is_expected.not_to include('Sommerlager')
+      end
+
+    end
+
+    context 'query' do
+      let(:subject) { assigns(:found_supercamps).map(&:name) }
+
+      it 'query finds supercamps anywhere' do
+        xhr :get, :query, group_id: group.id, camp_id: camp.id, q: 'sup', format: :js
+        is_expected.to include('Schekka Super', 'Tsueri Super')
+        is_expected.not_to include('Hauptlager')
+      end
+
+      it 'query excludes itself' do
+        xhr :get, :query, group_id: group.id, camp_id: camp.id, q: 'lager', format: :js
+        is_expected.not_to include('Sommerlager')
+      end
+
+      it 'does not query for less than 3 characters' do
+        xhr :get, :query, group_id: group.id, camp_id: camp.id, q: 'su', format: :js
+        is_expected.to be_empty
+      end
+
+    end
 
   end
 
-  describe 'inherit supercamp data' do
-
-    it 'authorizes request' do
-      # TODO
-    end
+  describe 'connect supercamp' do
 
     [:edit, :create].each do |form|
       context 'when coming from the ' + form.to_s + ' form' do
 
+        let(:camp) { events(:schekka_camp) }
+        let(:group) { camp.groups.first }
+        let(:supercamp_allows_sub_camps) { true }
+        let(:supercamp_state) { 'created' }
+        let(:event_form_data) { camp.attributes }
+        let(:result) { flash[:event_with_merged_supercamp] }
+
         before do
-          sign_in(people(:al_schekka))
+          camp.update(al_visiting: true,
+                      kantonalverband_rules_applied: true,
+                      lagerreglement_applied: true,
+                      coach_visiting: true,
+                      j_s_rules_applied: true,
+                      al_present: true)
+          supercamp.update(allow_sub_camps: supercamp_allows_sub_camps,
+                           state: supercamp_state)
+
           request.env['HTTP_REFERER'] = '/' + form.to_s
           if form == :create
             post :connect, group_id: group.id, supercamp_id: supercamp.id, event: event_form_data
@@ -36,66 +99,72 @@ describe SupercampsController do
           end
         end
 
-        let!(:supercamp_dates) { event_dates(:sixth, :sixth_two) }
-        let(:supercamp) { events(:bund_supercamp) }
-        let(:camp) do
-          events(:schekka_camp).tap do |c|
-            c.update(al_visiting: true,
-                     kantonalverband_rules_applied: true,
-                     lagerreglement_applied: true,
-                     coach_visiting: true,
-                     j_s_rules_applied: true,
-                     al_present: true)
+        context 'authorization' do
+
+          context 'checks that supercamp allows subcamps' do
+            let(:supercamp_allows_sub_camps) { false }
+            it do
+              expect(flash[:alert]).to eq('Das gewählte Lager erlaubt keine untergeordneten Lager')
+            end
           end
+
+          context 'checks that supercamp is in the correct state' do
+            let(:supercamp_state) { 'confirmed' }
+            it do
+              expect(flash[:alert]).to eq('Das gewählte übergeordnete Lager ist nicht im Status "Erstellt"')
+            end
+          end
+
         end
-        let(:event_form_data) { camp.attributes }
-        let(:group) { camp.groups.first }
-        let(:result) { flash[:event_with_merged_supercamp] }
 
         it 'redirects back' do
           expect(response).to redirect_to('/' + form.to_s)
         end
 
-        it 'name is calculated' do
-          expect(result[:name]).to eq(supercamp.name + ': ' + group.display_name)
-        end
+        context 'merge supercamp data' do
 
-        it 'description is calculated' do
-          expect(result[:description]).to eq((supercamp.description.to_s + "\n\n" + camp.description.to_s).strip)
-        end
-
-        it 'parent_id is correct' do
-          expect(result[:parent_id]).to eq(supercamp.id.to_s)
-        end
-
-        it 'dates from supercamp' do
-          attrs = %w[label location start_at finish_at]
-          expect(result[:dates_attributes].map { |d| d.slice(attrs) })
-            .to eq(supercamp.dates.map { |d| d.attributes.slice(attrs) })
-        end
-
-        [
-          :state, :lagerreglement_applied, :kantonalverband_rules_applied, :j_s_rules_applied,
-          :leader_id, :abteilungsleitung_id, :al_present, :al_visiting, :al_visiting_date, :coach_id,
-          :coach_visiting, :coach_visiting_date, :advisor_mountain_security, :advisor_snow_security,
-          :advisor_water_security
-        ].each do |attr|
-          it attr.to_s + ' from subcamp' do
-            expect(result[attr]).to eq(camp.attributes[attr.to_s])
+          it 'name is calculated' do
+            expect(result[:name]).to eq(supercamp.name + ': ' + group.display_name)
           end
-        end
 
-        [
-          :motto, :cost, :location, :canton, :coordinates, :altitude, :emergency_phone, :landlord,
-          :landlord_permission_obtained, :local_scout_contact_present, :local_scout_contact,
-          :j_s_kind, :j_s_security_mountain, :j_s_security_snow, :j_s_security_water,
-          :application_opening_at, :application_closing_at, :application_conditions, :maximum,
-          :external_applications, :signature, :signature_confirmation, :signature_confirmation_text,
-          :paper_application_required, :participants_can_apply, :participants_can_cancel
-        ].each do |attr|
-          it attr.to_s + ' from supercamp' do
-            expect(result[attr]).to eq(supercamp.attributes[attr.to_s])
+          it 'description is calculated' do
+            expect(result[:description]).to eq((supercamp.description.to_s + "\n\n" + camp.description.to_s).strip)
           end
+
+          it 'parent_id is correct' do
+            expect(result[:parent_id]).to eq(supercamp.id.to_s)
+          end
+
+          it 'dates from supercamp' do
+            attrs = %w(label location start_at finish_at)
+            expect(result[:dates_attributes].map { |d| d.slice(attrs) })
+              .to eq(supercamp.dates.map { |d| d.attributes.slice(attrs) })
+          end
+
+          [
+            :state, :lagerreglement_applied, :kantonalverband_rules_applied, :j_s_rules_applied,
+            :leader_id, :abteilungsleitung_id, :al_present, :al_visiting, :al_visiting_date, :coach_id,
+            :coach_visiting, :coach_visiting_date, :advisor_mountain_security, :advisor_snow_security,
+            :advisor_water_security
+          ].each do |attr|
+            it attr.to_s + ' from subcamp' do
+              expect(result[attr]).to eq(camp.attributes[attr.to_s])
+            end
+          end
+
+          [
+            :motto, :cost, :location, :canton, :coordinates, :altitude, :emergency_phone, :landlord,
+            :landlord_permission_obtained, :local_scout_contact_present, :local_scout_contact,
+            :j_s_kind, :j_s_security_mountain, :j_s_security_snow, :j_s_security_water,
+            :application_opening_at, :application_closing_at, :application_conditions, :maximum,
+            :external_applications, :signature, :signature_confirmation, :signature_confirmation_text,
+            :paper_application_required, :participants_can_apply, :participants_can_cancel
+          ].each do |attr|
+            it attr.to_s + ' from supercamp' do
+              expect(result[attr]).to eq(supercamp.attributes[attr.to_s])
+            end
+          end
+
         end
 
       end

--- a/spec/controllers/supercamps_controller_spec.rb
+++ b/spec/controllers/supercamps_controller_spec.rb
@@ -18,77 +18,88 @@ describe SupercampsController do
   end
 
   describe 'inherit supercamp data' do
-    before do
-      sign_in(people(:al_schekka))
-      request.env['HTTP_REFERER'] = '/'
-      post :connect, group_id: group.id, supercamp_id: supercamp.id, event: event_form_data
-    end
-
-    let!(:supercamp_dates) { event_dates(:sixth, :sixth_two) }
-    let(:supercamp) { events(:bund_supercamp) }
-    let(:camp) do
-      events(:schekka_camp).tap do |c|
-        c.update(al_visiting: true,
-                 kantonalverband_rules_applied: true,
-                 lagerreglement_applied: true,
-                 coach_visiting: true,
-                 j_s_rules_applied: true,
-                 al_present: true)
-      end
-    end
-    let(:event_form_data) { camp.attributes }
-    let(:group) { camp.groups.first }
-    let(:result) { flash[:event_with_merged_supercamp] }
 
     it 'authorizes request' do
       # TODO
     end
 
-    it 'redirects back' do
-      # TODO
-    end
+    [:edit, :create].each do |form|
+      context 'when coming from the ' + form.to_s + ' form' do
 
-    it 'name is calculated' do
-      expect(result[:name]).to eq(supercamp.name + ': ' + group.display_name)
-    end
+        before do
+          sign_in(people(:al_schekka))
+          request.env['HTTP_REFERER'] = '/' + form.to_s
+          if form == :create
+            post :connect, group_id: group.id, supercamp_id: supercamp.id, event: event_form_data
+          else
+            patch :connect, group_id: group.id, supercamp_id: supercamp.id, camp_id: camp.id, event: event_form_data
+          end
+        end
 
-    it 'description is calculated' do
-      expect(result[:description]).to eq((supercamp.description.to_s + "\n\n" + camp.description.to_s).strip)
-    end
+        let!(:supercamp_dates) { event_dates(:sixth, :sixth_two) }
+        let(:supercamp) { events(:bund_supercamp) }
+        let(:camp) do
+          events(:schekka_camp).tap do |c|
+            c.update(al_visiting: true,
+                     kantonalverband_rules_applied: true,
+                     lagerreglement_applied: true,
+                     coach_visiting: true,
+                     j_s_rules_applied: true,
+                     al_present: true)
+          end
+        end
+        let(:event_form_data) { camp.attributes }
+        let(:group) { camp.groups.first }
+        let(:result) { flash[:event_with_merged_supercamp] }
 
-    it 'parent_id is correct' do
-      expect(result[:parent_id]).to eq(supercamp.id.to_s)
-    end
+        it 'redirects back' do
+          expect(response).to redirect_to('/' + form.to_s)
+        end
 
-    it 'dates from supercamp' do
-      attrs = %w[label location start_at finish_at]
-      expect(result[:dates_attributes].map { |d| d.slice(attrs) })
-        .to eq(supercamp.dates.map { |d| d.attributes.slice(attrs) })
-    end
+        it 'name is calculated' do
+          expect(result[:name]).to eq(supercamp.name + ': ' + group.display_name)
+        end
 
-    [
-      :state, :lagerreglement_applied, :kantonalverband_rules_applied, :j_s_rules_applied,
-      :leader_id, :abteilungsleitung_id, :al_present, :al_visiting, :al_visiting_date, :coach_id,
-      :coach_visiting, :coach_visiting_date, :advisor_mountain_security, :advisor_snow_security,
-      :advisor_water_security
-    ].each do |attr|
-      it attr.to_s + ' from subcamp' do
-        expect(result[attr]).to eq(camp.attributes[attr.to_s])
+        it 'description is calculated' do
+          expect(result[:description]).to eq((supercamp.description.to_s + "\n\n" + camp.description.to_s).strip)
+        end
+
+        it 'parent_id is correct' do
+          expect(result[:parent_id]).to eq(supercamp.id.to_s)
+        end
+
+        it 'dates from supercamp' do
+          attrs = %w[label location start_at finish_at]
+          expect(result[:dates_attributes].map { |d| d.slice(attrs) })
+            .to eq(supercamp.dates.map { |d| d.attributes.slice(attrs) })
+        end
+
+        [
+          :state, :lagerreglement_applied, :kantonalverband_rules_applied, :j_s_rules_applied,
+          :leader_id, :abteilungsleitung_id, :al_present, :al_visiting, :al_visiting_date, :coach_id,
+          :coach_visiting, :coach_visiting_date, :advisor_mountain_security, :advisor_snow_security,
+          :advisor_water_security
+        ].each do |attr|
+          it attr.to_s + ' from subcamp' do
+            expect(result[attr]).to eq(camp.attributes[attr.to_s])
+          end
+        end
+
+        [
+          :motto, :cost, :location, :canton, :coordinates, :altitude, :emergency_phone, :landlord,
+          :landlord_permission_obtained, :local_scout_contact_present, :local_scout_contact,
+          :j_s_kind, :j_s_security_mountain, :j_s_security_snow, :j_s_security_water,
+          :application_opening_at, :application_closing_at, :application_conditions, :maximum,
+          :external_applications, :signature, :signature_confirmation, :signature_confirmation_text,
+          :paper_application_required, :participants_can_apply, :participants_can_cancel
+        ].each do |attr|
+          it attr.to_s + ' from supercamp' do
+            expect(result[attr]).to eq(supercamp.attributes[attr.to_s])
+          end
+        end
+
       end
-    end
 
-    [
-      :motto, :cost, :location, :canton, :coordinates, :altitude, :emergency_phone, :landlord,
-      :landlord_permission_obtained, :local_scout_contact_present, :local_scout_contact,
-      :j_s_kind, :j_s_security_mountain, :j_s_security_snow, :j_s_security_water,
-      :application_opening_at, :application_closing_at, :application_conditions, :maximum,
-      :external_applications, :signature, :signature_confirmation, :signature_confirmation_text,
-      :paper_application_required, :participants_can_apply, :participants_can_cancel
-    ].each do |attr|
-      it attr.to_s + ' from supercamp' do
-        expect(result[attr]).to eq(supercamp.attributes[attr.to_s])
-      end
     end
-
   end
 end

--- a/spec/fabricators/event/question_fabricator.rb
+++ b/spec/fabricators/event/question_fabricator.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+Fabricator(:question, class_name: 'Event::Question') do
+  event { Fabricate(:bund_camp) }
+  question { 'Ja oder nein?' }
+  choices { 'Ja,Nein' }
+  admin { false }
+end

--- a/spec/fixtures/event/dates.yml
+++ b/spec/fixtures/event/dates.yml
@@ -36,3 +36,15 @@ fifth:
   event: bund_camp
   start_at: <%= Time.zone.parse("2012-6-01") %>
   finish_at: <%= Time.zone.parse("2012-6-08") %>
+
+sixth:
+  label: Vorweekend
+  event: bund_supercamp
+  start_at: <%= Time.zone.parse("2012-6-01") %>
+  finish_at: <%= Time.zone.parse("2012-6-02") %>
+
+sixth_two:
+  label: Hauptlager
+  event: bund_supercamp
+  start_at: <%= Time.zone.parse("2012-7-01") %>
+  finish_at: <%= Time.zone.parse("2012-7-08") %>

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -93,10 +93,14 @@
 top_event:
   name: Top Event
   groups: bund
+  lft: 1
+  rgt: 2
 
 top_course:
   name: Top Course
   groups: be
+  lft: 3
+  rgt: 4
   type: Event::Course
   kind: lpk
   number: 445
@@ -107,6 +111,8 @@ top_course:
 bund_course:
   name: Bund Kurs
   groups: bund
+  lft: 5
+  rgt: 6
   kind: lpk
   type: Event::Course
   number: 876
@@ -114,16 +120,22 @@ bund_course:
 schekka_camp:
   name: Sommerlager
   groups: schekka
+  lft: 7
+  rgt: 8
   type: Event::Camp
 
 bund_camp:
   name: Sammellager
   groups: bund
+  lft: 9
+  rgt: 10
   type: Event::Camp
 
 bund_supercamp:
   name: Hauptlager
   groups: bund
+  lft: 11
+  rgt: 12
   type: Event::Camp
   allow_sub_camps: true
   state: created

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -120,3 +120,10 @@ bund_camp:
   name: Sammellager
   groups: bund
   type: Event::Camp
+
+bund_supercamp:
+  name: Hauptlager
+  groups: bund
+  type: Event::Camp
+  allow_sub_camps: true
+  state: created

--- a/spec/models/event/camp_spec.rb
+++ b/spec/models/event/camp_spec.rb
@@ -608,14 +608,33 @@ describe Event::Camp do
       is_expected.to respond_to :allow_sub_camps=
     end
 
-    it 'may only be attached to a super-camp that allows it' do
-      super_camp = events(:bund_camp)
-      sub_camp = events(:schekka_camp)
+    context 'attaching and detaching' do
 
-      super_camp.update_attribute(:allow_sub_camps, false)
-      sub_camp.parent_id = super_camp.id
+      let(:super_camp) { events(:bund_supercamp) }
+      let(:sub_camp) { events(:schekka_camp) }
 
-      expect(sub_camp).to_not be_valid
+      it 'may only be attached to a super-camp that allows it' do
+        super_camp.update_attribute(:allow_sub_camps, false)
+        sub_camp.parent_id = super_camp.id
+
+        expect(sub_camp).to_not be_valid
+      end
+
+      it 'may only be attached to a super-camp in created state' do
+        super_camp.update_attribute(:state, 'confirmed')
+        sub_camp.parent_id = super_camp.id
+
+        expect(sub_camp).to_not be_valid
+      end
+
+      it 'may be detached from a super-camp at any time' do
+        sub_camp.update_attribute(:parent_id, super_camp.id)
+        super_camp.update_attributes(state: 'confirmed', allow_sub_camps: false)
+        sub_camp.parent_id = nil
+
+        expect(sub_camp).to be_valid
+      end
+
     end
 
     context 'allowed to have sub_camps' do


### PR DESCRIPTION
**Depends on https://github.com/hitobito/hitobito/pull/861**

I also merged the commits of #120 into this preemptively, so there shouldn't be any merge conflicts once that one is merged.

Fixes hitobito/hitobito#835, fixes hitobito/hitobito#836