### PR TITLE
Lagerhierarchien: Tab "untergeordnete Lager"

### DIFF
--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-#  Copyright (c) 2012-2014, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -19,13 +17,14 @@ module Pbs::EventAbility
                            Group::Kantonalverband::VerantwortungKrisenteam,
                            Group::Kantonalverband::MitgliedKrisenteam].freeze
 
-  included do
+  included do # rubocop:disable Metrics/BlockLength
     on(Event) do
       permission(:any).may(:modify_superior).if_education_responsible
 
       permission(:any).may(:show_camp_application).for_leaded_events
       permission(:any).may(:create_camp_application).for_coached_events
       permission(:any).may(:show_details).if_participating_as_leader_role
+      permission(:any).may(:show_details).if_participating_as_leader_role_of_supercamp
 
       permission(:group_full).
         may(:show_camp_application, :show_details).
@@ -109,6 +108,21 @@ module Pbs::EventAbility
 
   def if_participating_as_leader_role
     participating? && participating_as_leader_role?
+  end
+
+  def if_participating_as_leader_role_of_supercamp
+    relevant_event_ids = event.self_and_ancestors.pluck(:id)
+    participating_event_ids = user_context.participations.collect(&:event_id)
+
+    relevant_participating_event_ids = (participating_event_ids & relevant_event_ids)
+
+    return unless relevant_participating_event_ids.any?
+
+    Event.where(id: relevant_participating_event_ids)
+         .joins(participations: [:roles])
+         .where('event_participations.person_id = ?', user.id)
+         .where('event_roles.type != ?', Event::Camp::Role::Participant.sti_name)
+         .present?
   end
 
   def if_part_of_krisenteam

--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -23,7 +23,6 @@ module Pbs::EventAbility
 
       permission(:any).may(:show_camp_application).for_leaded_events
       permission(:any).may(:create_camp_application).for_coached_events
-      # permission(:any).may(:show_details).if_participating_as_leader_role
       permission(:any).may(:show_details).if_participating_as_leader_role_of_supercamp
 
       permission(:group_full).
@@ -107,11 +106,6 @@ module Pbs::EventAbility
   def for_advised_or_participations_full_events
     for_advised_courses || for_participations_full_events
   end
-
-  # obsolete?
-  # def if_participating_as_leader_role
-  #   participating? && participating_as_leader_role?
-  # end
 
   def like_in_core_or_as_leader_of_supercamp
     for_participations_read_events_and_course_participants ||

--- a/app/controllers/subcamps_controller.rb
+++ b/app/controllers/subcamps_controller.rb
@@ -4,9 +4,9 @@
 #  https://github.com/hitobito/hitobito_pbs.
 
 class SubcampsController < ListController
-  helper_method :event
-
   self.nesting = Group
+
+  decorates :group, :events
 
   def self.model_class
     Event
@@ -14,8 +14,9 @@ class SubcampsController < ListController
 
   private
 
-  def event
-    @event ||= @group.events.find(params[:event_id])
+  def list_entries
+    supercamp = parent.events.find(params[:event_id])
+    supercamp.descendants
   end
 
   def authorize_class

--- a/app/controllers/subcamps_controller.rb
+++ b/app/controllers/subcamps_controller.rb
@@ -24,7 +24,7 @@ class SubcampsController < ListController
     case params[:filter]
     when 'direct' then event.sub_camps
     else               event.descendants # handles 'all' also
-    end
+    end.includes(:groups)
   end
 
   def authorize_class

--- a/app/controllers/subcamps_controller.rb
+++ b/app/controllers/subcamps_controller.rb
@@ -21,7 +21,10 @@ class SubcampsController < ListController
   end
 
   def list_entries
-    event.descendants
+    case params[:filter]
+    when 'direct' then event.sub_camps
+    else               event.descendants # handles 'all' also
+    end
   end
 
   def authorize_class

--- a/app/controllers/subcamps_controller.rb
+++ b/app/controllers/subcamps_controller.rb
@@ -6,7 +6,9 @@
 class SubcampsController < ListController
   self.nesting = Group
 
-  decorates :group, :events
+  helper_method :event
+
+  decorates :group, :event, :events
 
   def self.model_class
     Event
@@ -14,9 +16,12 @@ class SubcampsController < ListController
 
   private
 
+  def event
+    @event ||= parent.events.find(params[:event_id])
+  end
+
   def list_entries
-    supercamp = parent.events.find(params[:event_id])
-    supercamp.descendants
+    event.descendants
   end
 
   def authorize_class

--- a/app/controllers/subcamps_controller.rb
+++ b/app/controllers/subcamps_controller.rb
@@ -1,0 +1,26 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class SubcampsController < ListController
+  helper_method :group, :event
+
+  def self.model_class
+    Event
+  end
+
+  private
+
+  def group
+    @group ||= Group.find(params[:group_id])
+  end
+
+  def event
+    @event ||= group.events.find(params[:event_id])
+  end
+
+  def authorize_class
+    authorize!(:index_events, Group)
+  end
+end

--- a/app/controllers/subcamps_controller.rb
+++ b/app/controllers/subcamps_controller.rb
@@ -4,7 +4,9 @@
 #  https://github.com/hitobito/hitobito_pbs.
 
 class SubcampsController < ListController
-  helper_method :group, :event
+  helper_method :event
+
+  self.nesting = Group
 
   def self.model_class
     Event
@@ -12,12 +14,8 @@ class SubcampsController < ListController
 
   private
 
-  def group
-    @group ||= Group.find(params[:group_id])
-  end
-
   def event
-    @event ||= group.events.find(params[:event_id])
+    @event ||= @group.events.find(params[:event_id])
   end
 
   def authorize_class

--- a/app/helpers/filter_navigation/camps.rb
+++ b/app/helpers/filter_navigation/camps.rb
@@ -1,0 +1,38 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module FilterNavigation
+  class Camps < Base
+
+    def initialize(template)
+      super(template)
+      init_items
+    end
+
+    def active_label
+      label_for_filter(template.params.fetch(:filter, 'all'))
+    end
+
+    private
+
+    def init_items
+      filter_item('all')
+      filter_item('direct')
+    end
+
+    def filter_item(name)
+      item(label_for_filter(name), filter_path(name))
+    end
+
+    def label_for_filter(filter)
+      template.t("filter_navigation/camps.#{filter}")
+    end
+
+    def filter_path(name)
+      template.url_for(template.params.merge(filter: name))
+    end
+
+  end
+end

--- a/app/helpers/pbs/sheet/event.rb
+++ b/app/helpers/pbs/sheet/event.rb
@@ -22,7 +22,7 @@ module Pbs::Sheet::Event
                        event.course_kind? && view.can?(:manage_attendances, event)
                      end)),
       Sheet::Tab.new('events.tabs.sub_camps',
-                     :group_event_path, # :group_event_subcamps_path,
+                     :group_event_subcamps_path,
                      if: (lambda do |_view, _group, event|
                        event.allow_sub_camps
                      end))

--- a/app/helpers/sheet/subcamp.rb
+++ b/app/helpers/sheet/subcamp.rb
@@ -1,0 +1,10 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Sheet
+  class Subcamp < Base
+    self.parent_sheet = Sheet::Event
+  end
+end

--- a/app/views/subcamps/_list.html.haml
+++ b/app/views/subcamps/_list.html.haml
@@ -4,18 +4,4 @@
   or later. See the COPYING file at the top-level directory or at
   https://github.com/hitobito/hitobito_pbs.
 
-%h2 Gruppe
-%p
-  = parent.class
-  = parent
-
-%h2 Event
-%p
-  = event.class
-  = event
-
-%h2 SubCamps
-%ul
-  - event.descendants.each do |camp|
-    %li
-      = camp
+= list_table :name, :description, :applicant_count, :state, :groups

--- a/app/views/subcamps/_list.html.haml
+++ b/app/views/subcamps/_list.html.haml
@@ -9,4 +9,10 @@
 - content_for :filter do
   = FilterNavigation::Camps.new(self).to_s
 
-= list_table :name, :description, :applicant_count, :state, :groups
+= list_table do |t|
+  - t.col(t.sort_header(:name)) do |e|
+    %strong= link_to e.name, group_event_path(e.groups.first, e)
+  - t.attr(:description_short, t.attr_header(:description))
+  - t.attr(:booking_info)
+  - t.sortable_attr(:state)
+  - t.sortable_attr(:group_ids)

--- a/app/views/subcamps/_list.html.haml
+++ b/app/views/subcamps/_list.html.haml
@@ -4,4 +4,6 @@
   or later. See the COPYING file at the top-level directory or at
   https://github.com/hitobito/hitobito_pbs.
 
+- title event
+
 = list_table :name, :description, :applicant_count, :state, :groups

--- a/app/views/subcamps/_list.html.haml
+++ b/app/views/subcamps/_list.html.haml
@@ -6,4 +6,7 @@
 
 - title event
 
+- content_for :filter do
+  = FilterNavigation::Camps.new(self).to_s
+
 = list_table :name, :description, :applicant_count, :state, :groups

--- a/app/views/subcamps/index.html.haml
+++ b/app/views/subcamps/index.html.haml
@@ -1,0 +1,13 @@
+-#
+  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+  hitobito_pbs and licensed under the Affero General Public License version 3
+  or later. See the COPYING file at the top-level directory or at
+  https://github.com/hitobito/hitobito_pbs.
+
+%h2 Gruppe
+%p
+  = group
+
+%h2 Event
+%p
+  = event

--- a/app/views/subcamps/index.html.haml
+++ b/app/views/subcamps/index.html.haml
@@ -6,8 +6,16 @@
 
 %h2 Gruppe
 %p
-  = group
+  = parent.class
+  = parent
 
 %h2 Event
 %p
+  = event.class
   = event
+
+%h2 SubCamps
+%ul
+  - event.descendants.each do |camp|
+    %li
+      = camp

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -229,6 +229,10 @@ de:
   filter_navigation/events:
     canton: 'durchgeführt im Kanton'
 
+  filter_navigation/camps:
+    all: Alle untergeordneten Lager
+    direct: nur direkt untergeordnete Lager
+
   group:
     pending_approvals:
       index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -59,6 +59,8 @@ Rails.application.routes.draw do
           end
           resources :approvals, only: [:index]
         end
+
+        resources :subcamps, only: [:index]
       end
 
       get 'supercamps' => 'supercamps#available'

--- a/spec/abilities/event_ability_spec.rb
+++ b/spec/abilities/event_ability_spec.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-#  Copyright (c) 2012-2014, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -200,6 +198,18 @@ describe EventAbility do
                   participation: Fabricate(:event_participation, event: event, person: role.person))
         is_expected.to be_able_to(:update, event)
         is_expected.to be_able_to(:show_camp_application, event)
+      end
+
+      it 'is possible for leader of supercamp' do
+        event = Fabricate(:pbs_camp, groups: [group])
+        subcamp = Fabricate(:pbs_camp, groups: [group])
+        subcamp.move_to_child_of(event)
+
+        Fabricate(Event::Camp::Role::Leader.name,
+                  participation: Fabricate(:event_participation, event: event, person: role.person))
+        is_expected.to be_able_to(:show_details, subcamp)
+        is_expected.not_to be_able_to(:update, subcamp)
+        is_expected.not_to be_able_to(:show_camp_application, subcamp)
       end
 
       it 'is not possible for anyone' do

--- a/spec/abilities/event_ability_spec.rb
+++ b/spec/abilities/event_ability_spec.rb
@@ -208,6 +208,8 @@ describe EventAbility do
         Fabricate(Event::Camp::Role::Leader.name,
                   participation: Fabricate(:event_participation, event: event, person: role.person))
         is_expected.to be_able_to(:show_details, subcamp)
+        is_expected.to be_able_to(:index_participations, subcamp)
+
         is_expected.not_to be_able_to(:update, subcamp)
         is_expected.not_to be_able_to(:show_camp_application, subcamp)
       end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -150,7 +148,7 @@ describe EventsController do
       it 'can still submit camp when adding a supercamp' do
         group = event.groups.first
         event.update!(required_attrs_for_camp_submit)
-        event.update_attributes(parent_id: events(:bund_supercamp).id)
+        event.move_to_child_of(events(:bund_supercamp))
 
         put :create_camp_application, group_id: group.id, id: event.id
         expect(response).to redirect_to(group_event_path(group, event))

--- a/spec/controllers/subcamps_controller_spec.rb
+++ b/spec/controllers/subcamps_controller_spec.rb
@@ -1,0 +1,23 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+RSpec.describe SubcampsController, type: :controller do
+
+  let(:supercamp) { events(:bund_supercamp) }
+
+  before do
+    sign_in(people(:al_schekka))
+  end
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index, group_id: supercamp.groups.first, event_id: supercamp
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -93,6 +93,8 @@
 top_event:
   name: Top Event
   groups: bund
+  lft: 11
+  rgt: 12
 
 top_course:
   name: Top Course
@@ -103,6 +105,8 @@ top_course:
   priorization: true
   requires_approval: true
   external_applications: true
+  lft: 1
+  rgt: 2
 
 bund_course:
   name: Bund Kurs
@@ -110,16 +114,22 @@ bund_course:
   kind: lpk
   type: Event::Course
   number: 876
+  lft: 3
+  rgt: 4
 
 schekka_camp:
   name: Sommerlager
   groups: schekka
   type: Event::Camp
+  lft: 9
+  rgt: 10
 
 bund_camp:
   name: Sammellager
   groups: bund
   type: Event::Camp
+  lft: 7
+  rgt: 8
 
 bund_supercamp:
   name: Hauptlager
@@ -127,3 +137,5 @@ bund_supercamp:
   type: Event::Camp
   allow_sub_camps: true
   state: created
+  lft: 5
+  rgt: 6


### PR DESCRIPTION
Für die untergeordneten Lager gibt es jetzt eine Liste, die gefiltert werden kann. Sofern man auf einem übergeordneten Lager im Leitungsteam ist, hat man die Berechtigung, die Details und auch die Teilnehmer der untergeordneten Lager anzusehen.

Fixes hitobito/hitobito#832