### PR TITLE
Fix bug in return path

### DIFF
--- a/app/controllers/pbs/roles_controller.rb
+++ b/app/controllers/pbs/roles_controller.rb
@@ -21,11 +21,12 @@ module Pbs::RolesController
   end
 
   def after_create_location_with_deleted(new_person)
-    if model_params[:deleted_at]
-      group_people_path(entry.group_id)
-    else
-      after_create_location_without_deleted(new_person)
-    end
+    return_path ||
+      if model_params[:deleted_at].present?
+        group_people_path(entry.group_id)
+      else
+        after_create_location_without_deleted(new_person)
+      end
   end
 
   def after_update_location_with_deleted

--- a/spec/controllers/event/approvals_controller_spec.rb
+++ b/spec/controllers/event/approvals_controller_spec.rb
@@ -91,9 +91,9 @@ describe Event::ApprovalsController do
 
       expect(assigns(:approvals).keys).to eq(list)
 
-      expect(assigns(:approvals)[@p1]).to eq([@a11, @a12, @a13])
-      expect(assigns(:approvals)[@p2]).to eq([@a21, @a22])
-      expect(assigns(:approvals)[@p3]).to eq([@a31, @a32])
+      expect(assigns(:approvals)[@p1]).to match_array([@a11, @a12, @a13])
+      expect(assigns(:approvals)[@p2]).to match_array([@a21, @a22])
+      expect(assigns(:approvals)[@p3]).to match_array([@a31, @a32])
     end
 
     def create_approval(participation, layer, approved)


### PR DESCRIPTION
```model_params[:deleted_at]``` is always sent in the form, though with a ```''``` value. This leads  to wrong behaviour when creating roles.