### PR TITLE
Adapt French name for 'Elternrat' from comité des parents to conseil des parents, according to current wording.

### DIFF
--- a/config/locales/models.pbs.fr.yml
+++ b/config/locales/models.pbs.fr.yml
@@ -29,8 +29,8 @@ fr:
         other: Commissions
         long: Commission fédérale
       group/elternrat:
-        one: Comité des parents
-        other: Comités des parents
+        one: Conseil des parents
+        other: Conseil des parents
       group/gremium:
         one: Commission
         other: Commissions


### PR DESCRIPTION
Die französische Bezeichnung "comité des parents" wurde im PBS-Wording durch "conseil des parents" abgelöst. Bin nicht sicher, ob ich die Änderung im richtigen File und an der richtigen Stelle vorgeschlagen habe.

![image](https://user-images.githubusercontent.com/5032385/69623894-f192bb80-1043-11ea-80c3-3583edbfa855.png)
