### PR TITLE
Topic wording elternrat: Adapt French name for 'Elternrat' from 'comité des parents' to 'conseil des parents', according to current wording.

### DIFF
--- a/config/locales/models.pbs.fr.yml
+++ b/config/locales/models.pbs.fr.yml
@@ -30,7 +30,7 @@ fr:
         long: Commission fédérale
       group/elternrat:
         one: Conseil des parents
-        other: Conseil des parents
+        other: Conseils des parents
       group/gremium:
         one: Commission
         other: Commissions

--- a/config/locales/models.pbs.fr.yml
+++ b/config/locales/models.pbs.fr.yml
@@ -29,8 +29,8 @@ fr:
         other: Commissions
         long: Commission fédérale
       group/elternrat:
-        one: Comité des parents
-        other: Comités des parents
+        one: Conseil des parents
+        other: Conseil des parents
       group/gremium:
         one: Commission
         other: Commissions


### PR DESCRIPTION
Die französische Bezeichnung "comité des parents" wurde im PBS-Wording durch "conseil des parents" abgelöst. Bin nicht sicher, ob ich die Änderung im richtigen File und an der richtigen Stelle vorgeschlagen habe.

![image](https://user-images.githubusercontent.com/5032385/69714554-e18fe000-1106-11ea-9eb4-f1a0af8d6eb1.png)
