### PR TITLE
Add sub-camps to serializer and add tests

### DIFF
--- a/app/serializers/pbs/event_link_serializer.rb
+++ b/app/serializers/pbs/event_link_serializer.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Pbs::EventLinkSerializer < ::ApplicationSerializer
+  extend ActiveSupport::Concern
+
+  schema do
+    json_api_properties
+
+    map_properties :id
+    property :href, h.event_url(item.id, format: :json)
+  end
+end
+

--- a/app/serializers/pbs/event_serializer.rb
+++ b/app/serializers/pbs/event_serializer.rb
@@ -31,6 +31,8 @@ module Pbs::EventSerializer
                                            :j_s_security_water,
                                            :required_contact_attrs,
                                            :hidden_contact_attrs))
+
+        entities :sub_camps, item.sub_camps, EventLinkSerializer
     end
   end
 end

--- a/app/serializers/pbs/event_serializer.rb
+++ b/app/serializers/pbs/event_serializer.rb
@@ -32,7 +32,7 @@ module Pbs::EventSerializer
                                            :required_contact_attrs,
                                            :hidden_contact_attrs))
 
-        entities :sub_camps, item.sub_camps, EventLinkSerializer
+        entities :sub_camps, item.sub_camps, Pbs::EventLinkSerializer
     end
   end
 end

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -7,7 +7,8 @@ require 'spec_helper'
 
 describe EventSerializer do
   let(:camp) { Fabricate(:pbs_camp) }
-  let(:serializer) { EventSerializer.new(camp)}
+  let(:controller) { double.as_null_object }
+  let(:serializer) { ::EventSerializer.new(camp, controller: controller)}
   subject(:serialized) { serializer.to_hash }
 
   it { is_expected.to eq({ id: camp.id, href: event_url(item.id, format: :json) }) }

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -5,7 +5,7 @@
 
 require 'spec_helper'
 
-describe Pbs::EventSerializer do
+describe EventSerializer do
   let(:camp) { Fabricate(:pbs_camp) }
   let(:serializer) { EventSerializer.new(camp)}
   subject(:serialized) { serializer.to_hash }

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -1,0 +1,14 @@
+#  Copyright (c) 2019, Pfadibewegung Schweiz This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe Pbs::EventSerializer do
+  let(:camp) { Fabricate(:pbs_camp) }
+  let(:serializer) { EventSerializer.new(camp)}
+  subject(:serialized) { serializer.to_hash }
+
+  it { is_expected.to eq({ id: camp.id, href: event_url(item.id, format: :json) }) }
+end


### PR DESCRIPTION
This PR lists the subcamps as links in the serialized camp:

```
...
{
  "events": [
    {
      "id": "223",
      "type": "events",
      "name": "Bundeslager 2021 - Gesamtlager",

      ...

      "links": {
        "sub_camps": [
          224,
          ...
        ],
        ...
      }
    }

    ...
  ],

  "linked": {
    "events": [
      {
        "id": 224,
        "href": "http://localhost:3000/de/events/224.json"
      },
      ...
    ],
  }
  
  ...
}
```

I'm having troubles with the wagon specs locally, but will investigate some more.

@lukaseisenring: This will do, right?