### PR TITLE
Advanced households export (without disturbing the UI)

### DIFF
--- a/app/controllers/pbs/people_controller.rb
+++ b/app/controllers/pbs/people_controller.rb
@@ -10,6 +10,7 @@ module Pbs::PeopleController
 
   included do
     alias_method_chain :prepare_tabular_entries, :layer_group
+    alias_method_chain :render_tabular_in_background, :detail
   end
 
   private
@@ -17,6 +18,13 @@ module Pbs::PeopleController
   def prepare_tabular_entries_with_layer_group(entries, full)
     entries = prepare_tabular_entries_without_layer_group(entries, full)
     entries.includes(:primary_group)
+  end
+
+  def render_tabular_in_background_with_detail(format, full, filename)
+    Export::PeopleExportJob.new(
+      format, current_person.id, @group.id, list_filter_args,
+      params.slice(:household, :selection, :household_details).merge(full: full, filename: filename)
+    ).enqueue!
   end
 
 end

--- a/app/controllers/pbs/subscriptions_controller.rb
+++ b/app/controllers/pbs/subscriptions_controller.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Pbs::SubscriptionsController
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :render_tabular_in_background, :detail
+  end
+
+  def render_tabular_in_background_with_detail(format)
+    with_async_download_cookie(format, "subscriptions_#{mailing_list.id}") do |filename|
+      Export::SubscriptionsJob.new(format,
+                                   current_person.id,
+                                   mailing_list.id,
+                                   params.slice(:household, :household_details)
+                                    .merge(filename: filename)).enqueue!
+    end
+  end
+
+end

--- a/app/domain/pbs/export/tabular/people/households_full.rb
+++ b/app/domain/pbs/export/tabular/people/households_full.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+#  Copyright (c) 2018, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Pbs::Export::Tabular::People
+  class HouseholdsFull < Export::Tabular::People::Households
+
+    def person_attributes
+      super +
+      [:correspondence_language, :kantonalverband_id,
+       :id, :layer_group_id, :company_name, :company]
+    end
+  end
+end

--- a/app/domain/pbs/export/tabular/people/participations_households_full.rb
+++ b/app/domain/pbs/export/tabular/people/participations_households_full.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+#  Copyright (c) 2018-2018, hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::Tabular::People
+  class ParticipationsHouseholdsFull < HouseholdsFull
+    def initialize(list)
+      super(people(list))
+    end
+
+    def people(list)
+      list.map(&:person)
+    end
+  end
+end

--- a/app/jobs/pbs/export/event_participations_export_job.rb
+++ b/app/jobs/pbs/export/event_participations_export_job.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::EventParticipationsExportJob
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :exporter, :detail
+  end
+
+  def exporter_with_detail
+    if @options[:household_details]
+      return Pbs::Export::Tabular::People::ParticipationsHouseholdsFull
+    end
+    exporter_without_detail
+  end
+
+end

--- a/app/jobs/pbs/export/people_export_job.rb
+++ b/app/jobs/pbs/export/people_export_job.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::PeopleExportJob
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :exporter, :detail
+  end
+
+  def exporter_with_detail
+    return Pbs::Export::Tabular::People::HouseholdsFull if  @options[:household_details]
+    exporter_without_detail
+  end
+
+end

--- a/app/jobs/pbs/export/subscriptions_job.rb
+++ b/app/jobs/pbs/export/subscriptions_job.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::Export::SubscriptionsJob
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :exporter, :detail
+  end
+
+  def exporter_with_detail
+    return Pbs::Export::Tabular::People::HouseholdsFull if  @options[:household_details]
+    exporter_without_detail
+  end
+
+end

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -65,6 +65,15 @@ module HitobitoPbs
         :include, Pbs::Export::Tabular::People::PeopleFull
       )
       Export::Tabular::Events::BsvRow.send :include, Pbs::Export::Tabular::Events::BsvRow
+      Export::PeopleExportJob.send(
+       :include, Pbs::Export::PeopleExportJob
+      )
+      Export::EventParticipationsExportJob.send(
+        :include, Pbs::Export::EventParticipationsExportJob
+      )
+      Export::SubscriptionsJob.send(
+        :include, Pbs::Export::SubscriptionsJob
+      )
 
       ### abilities
       Ability.store.register Event::ApprovalAbility
@@ -112,6 +121,7 @@ module HitobitoPbs
       Event::QualificationsController.send :include, Pbs::Event::QualificationsController
       QualificationsController.send :include, Pbs::QualificationsController
       Person::QueryController.search_columns << :pbs_number
+      SubscriptionsController.send :include, Pbs::SubscriptionsController
 
       ### sheets
       Sheet::Group.send :include, Pbs::Sheet::Group

--- a/spec/domain/export/tabular/people/households_spec.rb
+++ b/spec/domain/export/tabular/people/households_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+#  Copyright (c) 2012-2018, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Pbs::Export::Tabular::People::HouseholdsFull do
+
+  let(:leader) { people(:top_leader) }
+  let(:member) { people(:bottom_member) }
+
+  def households(list = [])
+    Pbs::Export::Tabular::People::HouseholdsFull.new(list)
+  end
+
+  context 'header' do
+    it 'includes name, address attributes and layer group columns' do
+      expect(households.attributes).to eq [:name, :address, :zip_code, :town,
+                                           :country, :layer_group, :correspondence_language,
+                                           :kantonalverband_id, :id, :layer_group_id,
+                                           :company_name, :company]
+    end
+  end
+
+end


### PR DESCRIPTION
The households export with more detail will only be available through a specific URL. The option in the drop down is not included anymore. This way we don't disturb the UI and still offer a solution for users who need more information in the households export.

Also the group_id is included in the people_controller to match the core query again (after the changes from the performance optimization). 

This will replace https://github.com/hitobito/hitobito_pbs/pull/87