### PR TITLE
Make entities visible again

### DIFF
--- a/app/serializers/pbs/event_serializer.rb
+++ b/app/serializers/pbs/event_serializer.rb
@@ -10,34 +10,39 @@ module Pbs::EventSerializer
 
   included do
     extension(:public) do |_|
-      used_attributes = item.used_attributes & [:applicant_count,
-                                                :expected_participants_wolf_f,
-                                                :expected_participants_wolf_m,
-                                                :expected_participants_pfadi_f,
-                                                :expected_participants_pfadi_m,
-                                                :expected_participants_pio_f,
-                                                :expected_participants_pio_m,
-                                                :expected_participants_rover_f,
-                                                :expected_participants_rover_m,
-                                                :expected_participants_leitung_f,
-                                                :expected_participants_leitung_m,
-                                                :canton,
-                                                :coordinates,
-                                                :altitude,
-                                                :emergency_phone,
-                                                :j_s_kind,
-                                                :j_s_security_snow,
-                                                :j_s_security_mountain,
-                                                :j_s_security_water,
-                                                :required_contact_attrs,
-                                                :hidden_contact_attrs]
+      used_attributes = item.used_attributes(:applicant_count,
+                                             :expected_participants_wolf_f,
+                                             :expected_participants_wolf_m,
+                                             :expected_participants_pfadi_f,
+                                             :expected_participants_pfadi_m,
+                                             :expected_participants_pio_f,
+                                             :expected_participants_pio_m,
+                                             :expected_participants_rover_f,
+                                             :expected_participants_rover_m,
+                                             :expected_participants_leitung_f,
+                                             :expected_participants_leitung_m,
+                                             :canton,
+                                             :coordinates,
+                                             :altitude,
+                                             :emergency_phone,
+                                             :j_s_kind,
+                                             :j_s_security_snow,
+                                             :j_s_security_mountain,
+                                             :j_s_security_water,
+                                             :required_contact_attrs,
+                                             :hidden_contact_attrs
+                                            )
       map_properties(*used_attributes)
 
-      if item.used_attributes.include?(:abteilungsleitung_id)
+      if item.used_attributes(:abteilungsleitung_id).any?
         entity :abteilungsleitung, item.abteilungsleitung, ContactSerializer
       end
 
-      if item.used_attributes.include?(:coach_id)
+      if item.used_attributes(:leader_id).any?
+        entity :leader, item.leader, ContactSerializer
+      end
+
+      if item.used_attributes(:coach_id).present?
         entity :coach, item.coach, ContactSerializer
       end
 

--- a/spec/fixtures/event/participations.yml
+++ b/spec/fixtures/event/participations.yml
@@ -29,3 +29,9 @@ schekka_camp_participant:
   person: al_schekka
   active: true
   state: assigned
+
+schekka_supercamp_leader:
+  event: schekka_supercamp
+  person: bulei
+  active: true
+  state: assigned

--- a/spec/fixtures/event/roles.yml
+++ b/spec/fixtures/event/roles.yml
@@ -20,3 +20,7 @@ schekka_camp_leader:
 schekka_camp_tn:
   participation: schekka_camp_participant
   type: Event::Camp::Role::Participant
+
+schekka_supercamp_leader:
+  participation: schekka_supercamp_leader
+  type: Event::Camp::Role::Leader

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -22,7 +22,15 @@ describe EventSerializer do
       expect(event[:links]).not_to have_key :sub_camps
       expect(event[:links]).not_to have_key :super_camp
     end
- end
+
+    it 'includes leader' do
+      hash = EventSerializer.new(event.decorate, controller: controller).to_hash
+      event = hash[:events].first
+
+      expect(event[:links]).not_to have_key :sub_camps
+
+    end
+  end
 
   context 'sub_camps' do
     before { sub_camp.update(parent_id: super_camp.id) }

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -43,6 +43,7 @@ describe EventSerializer do
       expect(event[:links]).to have_key :abteilungsleitung
       expect(hash[:linked]['events'].first[:id]).to eq sub_camp.id
     end
+  end
 
   context 'sub_camps' do
     before { sub_camp.update(parent_id: super_camp.id) }

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -6,7 +6,6 @@
 require 'spec_helper'
 
 describe EventSerializer do
-  let(:event)          { events(:top_event) }
   let(:super_camp)     { events(:bund_supercamp) }
   let(:sub_camp)       { events(:schekka_camp) }
   let(:controller)     { double().as_null_object }
@@ -15,6 +14,7 @@ describe EventSerializer do
 
 
   context 'event' do
+    let(:event)          { events(:top_event) }
 
     it 'does not have sub_camps nor super_camp  links' do
       hash = EventSerializer.new(event.decorate, controller: controller).to_hash
@@ -25,15 +25,15 @@ describe EventSerializer do
   end
 
   context 'with leader and abteilungsleitung' do
-    let(:leader) { people(:al_schekka) }
-    let(:abteilungsleitung) { people(:al_berchtold) }
+    let(:event) { events(:schekka_supercamp) }
+    let!(:leader_role) { event_roles(:schekka_camp_leader) }
+    let!(:abteilungsleitung) { people(:al_schekka) }
 
     before do
-      event.leader = leader
-      event.abteilungsleitung = abteilungsleitung
+      event.send(:assign_abteilungsleitung)
       event.save
+      sub_camp.update_attributes(parent_id: event.id)
     end
-
 
     it 'includes leader' do
       hash = EventSerializer.new(event.decorate, controller: controller).to_hash

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -22,15 +22,27 @@ describe EventSerializer do
       expect(event[:links]).not_to have_key :sub_camps
       expect(event[:links]).not_to have_key :super_camp
     end
+  end
+
+  context 'with leader and abteilungsleitung' do
+    let(:leader) { people(:al_schekka) }
+    let(:abteilungsleitung) { people(:al_berchtold) }
+
+    before do
+      event.leader = leader
+      event.abteilungsleitung = abteilungsleitung
+      event.save
+    end
+
 
     it 'includes leader' do
       hash = EventSerializer.new(event.decorate, controller: controller).to_hash
       event = hash[:events].first
 
-      expect(event[:links]).not_to have_key :sub_camps
-
+      expect(event[:links]).to have_key :leader
+      expect(event[:links]).to have_key :abteilungsleitung
+      expect(hash[:linked]['events'].first[:id]).to eq sub_camp.id
     end
-  end
 
   context 'sub_camps' do
     before { sub_camp.update(parent_id: super_camp.id) }

--- a/spec/serializers/pbs/event_serializer_spec.rb
+++ b/spec/serializers/pbs/event_serializer_spec.rb
@@ -6,6 +6,7 @@
 require 'spec_helper'
 
 describe EventSerializer do
+  let(:event)          { events(:top_event) }
   let(:super_camp)     { events(:bund_supercamp) }
   let(:sub_camp)       { events(:schekka_camp) }
   let(:controller)     { double().as_null_object }
@@ -14,7 +15,6 @@ describe EventSerializer do
 
 
   context 'event' do
-    let(:event) { events(:top_event) }
 
     it 'does not have sub_camps nor super_camp  links' do
       hash = EventSerializer.new(event.decorate, controller: controller).to_hash


### PR DESCRIPTION
Mit dem letzten [Commit auf dem PBS EventSerializer](https://github.com/hitobito/hitobito_pbs/commit/a12aa074d92a2c32561bdd6bc4f4278be5da3159#diff-fdff37addd8af470d6ee4602843f83db) ist ein Fehler entstanden, worauf die verlinkten Personen nicht mehr serialisiert wurden.

Das Problem ist entstanden, weil die Methode ```used_attributes``` auf dem Application Decorator  Argumente braucht und den Array bereits filtert: https://github.com/hitobito/hitobito/blob/d615ffff9bde1cc390604b2f8a3eb2a1c8f7499f/app/decorators/application_decorator.rb#L21-L23

Allenfalls wäre es schön, die Methode im ApplicationDecorator zu refactoren mit dem ```&``` und sicherstellen, dass die Methode nicht ohne Argument aufgerufen werden kann (gibt im Moment einfach einen leeren Array zurück).

Bitte möglichst schnell mergen, wir sind auf die verlinkten Models angewiesen.