### PR TITLE
Angepasste URL für das Export-Tool

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,7 +26,7 @@ application:
       it:
         "Aiuto e assistenza": https://www.scout.ch/it/scout-online/midata/utente/utente?set_language=it
         "Datenschutz": https://www.scout.ch/it/scout-online/midata/utente/datennutzung_midata_pbs_it/at_download/file
-  course_confirmation_url: "http://pbs01.smartness.ch/kurs/renderer/pdf/%{course_kind_confirmation_name}/%{locale}"
+  course_confirmation_url: "https://corsiexp.scouts.ch/benevole/renderer/pdf/%{course_kind_confirmation_name}/%{locale}"
 
 
 # The person with this email has root access to everything


### PR DESCRIPTION
Mit der URL scouts.ch können wir die DNS-Einträge jederzeit selber ändern (z.B. wenn wir mal auf einen anderen Server zügeln). Ausserdem hat die Domain etwas mehr Bezug zur Pfadi ;)