### PR TITLE
Move calculated fields to Campy

### DIFF
--- a/app/models/event/camp.rb
+++ b/app/models/event/camp.rb
@@ -186,18 +186,6 @@ class Event::Camp < Event
     end
   end
 
-  def total_expected_participants
-    %w(wolf pfadi pio rover).product(%w(f m)).map do |level, gender|
-      send("expected_participants_#{level}_#{gender}") || 0
-    end.inject(&:+)
-  end
-
-  def total_expected_leading_participants
-    %w(leitung).product(%w(f m)).map do |level, gender|
-      send("expected_participants_#{level}_#{gender}") || 0
-    end.inject(&:+)
-  end
-
   private
 
   def assign_abteilungsleitung

--- a/app/models/event/campy.rb
+++ b/app/models/event/campy.rb
@@ -111,6 +111,18 @@ module Event::Campy
     end
   end
 
+  def total_expected_participants
+    %w(wolf pfadi pio rover).product(%w(f m)).map do |level, gender|
+      send("expected_participants_#{level}_#{gender}") || 0
+    end.inject(&:+)
+  end
+
+  def total_expected_leading_participants
+    %w(leitung).product(%w(f m)).map do |level, gender|
+      send("expected_participants_#{level}_#{gender}") || 0
+    end.inject(&:+)
+  end
+
   private
 
   def reset_coach_confirmed_if_changed

--- a/spec/models/event/campy_course_spec.rb
+++ b/spec/models/event/campy_course_spec.rb
@@ -58,6 +58,14 @@ describe Event::Course do
       subject.expected_participants_pio_m = 42
       is_expected.to be_valid
     end
+
+    it 'responds to total_expected_participants' do
+      is_expected.to respond_to :total_expected_participants
+    end
+
+    it 'responds to total_expected_leading_participants' do
+      is_expected.to respond_to :total_expected_leading_participants
+    end
   end
 
   context '#j_s_kind' do


### PR DESCRIPTION
This fixes a bug that caused campy courses in which the expected participants are filled in to raise an exception.
https://help.puzzle.ch/#ticket/zoom/1149