### PR TITLE
Validate coordinates in groupfinder fields

### DIFF
--- a/app/models/geolocation.rb
+++ b/app/models/geolocation.rb
@@ -20,8 +20,10 @@ class Geolocation < ActiveRecord::Base
 
   belongs_to :geolocatable, polymorphic: true
 
-  validates :lat, format: { with: /\A-?([1-8]?[0-9]\.{1}\d{1,6}\z|90\.{1}0{1,6}\z)/ }
-  validates :long, format: { with: /\A-?((([1]?[0-7][0-9]|[1-9]?[0-9])\.{1}\d{1,6}\z)|[1]?[1-8][0]\.{1}0{1,6}\z)/ }
+  validates :lat, format: { with: %r{\A-?([1-8]?[0-9]
+    \.{1}\d{1,6}\z|90\.{1}0{1,6}\z)}x }
+  validates :long, format: { with: %r{\A-?((([1]?[0-7][0-9]|[1-9]?[0-9])
+    \.{1}\d{1,6}\z)|[1]?[1-8][0]\.{1}0{1,6}\z)}x }
 
   validates_by_schema
 

--- a/app/models/geolocation.rb
+++ b/app/models/geolocation.rb
@@ -20,10 +20,10 @@ class Geolocation < ActiveRecord::Base
 
   belongs_to :geolocatable, polymorphic: true
 
-  validates :lat, format: { with: %r{\A-?([1-8]?[0-9]
-    \.{1}\d{1,6}\z|90\.{1}0{1,6}\z)}x }
-  validates :long, format: { with: %r{\A-?((([1]?[0-7][0-9]|[1-9]?[0-9])
-    \.{1}\d{1,6}\z)|[1]?[1-8][0]\.{1}0{1,6}\z)}x }
+  validates :lat, numericality: { greater_than_or_equal_to:  -90,
+    less_than_or_equal_to:  90 }, format: { with: /\A\d+\.\d{1,6}\z/ }
+  validates :long, numericality: { greater_than_or_equal_to:  -180,
+    less_than_or_equal_to:  180 }, format: { with: /\A\d+\.\d{1,6}\z/ }
 
   validates_by_schema
 

--- a/app/models/geolocation.rb
+++ b/app/models/geolocation.rb
@@ -20,6 +20,9 @@ class Geolocation < ActiveRecord::Base
 
   belongs_to :geolocatable, polymorphic: true
 
+  validates :lat, format: { with: /\A-?([1-8]?[0-9]\.{1}\d{1,6}\z|90\.{1}0{1,6}\z)/ }
+  validates :long, format: { with: /\A-?((([1]?[0-7][0-9]|[1-9]?[0-9])\.{1}\d{1,6}\z)|[1]?[1-8][0]\.{1}0{1,6}\z)/ }
+
   validates_by_schema
 
   def to_s

--- a/app/models/group/abteilung.rb
+++ b/app/models/group/abteilung.rb
@@ -44,6 +44,10 @@ class Group::Abteilung < Group
   GENDERS = %w(m w).freeze
 
   GEOLOCATION_COUNT_LIMIT = 4
+  GEOLOCATION_SWITZERLAND_NORTH_LIMIT = 47.811263
+  GEOLOCATION_SWITZERLAND_SOUTH_LIMIT = 45.811958
+  GEOLOCATION_SWITZERLAND_EAST_LIMIT = 10.523665
+  GEOLOCATION_SWITZERLAND_WEST_LIMIT = 5.922318
 
   CONTENT_GROUPFINDER_FIELDS_INFO = 'groupfinder_fields_info'.freeze
 
@@ -73,6 +77,15 @@ class Group::Abteilung < Group
   # Can't use validates :geolocations, length: { ... } because it counts in the
   # nested records that are #marked_for_destruction?
   validate :assert_geolocation_count
+  validate do
+    is_valid = geolocations.all? do |geolocation|
+      GEOLOCATION_SWITZERLAND_SOUTH_LIMIT < geolocation.lat.to_f \
+      && geolocation.lat.to_f < GEOLOCATION_SWITZERLAND_NORTH_LIMIT \
+      && GEOLOCATION_SWITZERLAND_WEST_LIMIT < geolocation.long.to_f \
+      && geolocation.long.to_f < GEOLOCATION_SWITZERLAND_EAST_LIMIT
+    end
+      errors.add(:base, :geo_not_in_switzerland) if !is_valid
+  end
 
   include I18nEnums
   i18n_enum :gender, GENDERS

--- a/app/models/group/abteilung.rb
+++ b/app/models/group/abteilung.rb
@@ -84,7 +84,7 @@ class Group::Abteilung < Group
       && GEOLOCATION_SWITZERLAND_WEST_LIMIT < geolocation.long.to_f \
       && geolocation.long.to_f < GEOLOCATION_SWITZERLAND_EAST_LIMIT
     end
-      errors.add(:base, :geo_not_in_switzerland) if !is_valid
+    errors.add(:base, :geo_not_in_switzerland) if !is_valid
   end
 
   include I18nEnums

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1211,4 +1211,7 @@ de:
         crisis:
           another_active: Eine andere Krise ist bereits aktiv auf dieser Gruppe
         group/abteilung:
+          attributes:
+            base:
+              geo_not_in_switzerland: Diese Koordinaten liegen nicht in der Schweiz.
           too_many_geolocations: dürfen nicht mehr als %{max} sein

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -81,8 +81,8 @@ describe GroupsController do
 
       context 'adding geolocations' do
         let(:params) { {group: {geolocations_attributes: [
-          {lat: 'lat1', long: 'long1', _destroy: 'false'},
-          {lat: '2 123 123', long: '1 123 123', _destroy: 'false'},
+          {lat: '47.0', long: '7.0', _destroy: 'false'},
+          {lat: '47.5', long: '8.5', _destroy: 'false'},
         ]}} }
 
         it 'adds geolocations' do
@@ -106,9 +106,9 @@ describe GroupsController do
         end
 
         let(:params) { {group: {geolocations_attributes: [
-          {id: Geolocation.last.id, lat: 'lat1', long: 'long1', _destroy: 1},
-          {lat: 'lat1', long: 'long1', _destroy: 'false'},
-          {lat: '2 123 123', long: '1 123 123', _destroy: 'false'},
+          {id: Geolocation.last.id, lat: '47.0', long: '7.0', _destroy: 1},
+          {lat: '47.0', long: '7.0', _destroy: 'false'},
+          {lat: '47.5', long: '8.5', _destroy: 'false'},
         ]}} }
 
         it 'allows to add more geolocations than allowed if removing others' do
@@ -121,8 +121,8 @@ describe GroupsController do
         let!(:geolocation2) { Fabricate(Geolocation.name.downcase.to_sym, geolocatable: test_entry) }
         let!(:geolocation3) { Fabricate(Geolocation.name.downcase.to_sym, geolocatable: test_entry) }
         let(:params) { {group: {geolocations_attributes: [
-          {id: geolocation1.id.to_s, lat: 'lat1', long: 'long1', _destroy: 1},
-          {id: geolocation2.id.to_s, lat: '2 123 123', long: '1 123 123', _destroy: 1},
+          {id: geolocation1.id.to_s, lat: '47.0', long: '7.0', _destroy: 1},
+          {id: geolocation2.id.to_s, lat: '47.5', long: '8.5', _destroy: 1},
         ]}} }
 
         it 'removes geolocations' do

--- a/spec/fabricators/geolocation_fabricator.rb
+++ b/spec/fabricators/geolocation_fabricator.rb
@@ -17,6 +17,6 @@
 #
 
 Fabricator(:geolocation) do
-  lat   { Faker::Number.number(7) }
-  long  { Faker::Number.number(7) }
+  lat   { (46.0 + (rand * 1000).floor / 1000.0).to_s }
+  long  { ((6000 + 4 * rand * 1000).floor / 1000.0).to_s }
 end

--- a/spec/fabricators/geolocation_fabricator.rb
+++ b/spec/fabricators/geolocation_fabricator.rb
@@ -17,6 +17,6 @@
 #
 
 Fabricator(:geolocation) do
-  lat   { (46.0 + (rand * 1000).floor / 1000.0).to_s }
-  long  { ((6000 + 4 * rand * 1000).floor / 1000.0).to_s }
+  lat   { (46.0 + 1.5 * rand).round(3).to_s }
+  long  { (6.0 + 4 * rand).round(3).to_s }
 end

--- a/spec/models/geolocation_spec.rb
+++ b/spec/models/geolocation_spec.rb
@@ -25,4 +25,12 @@ describe Geolocation do
     expect(subject.to_s).to eq("(#{subject.lat}, #{subject.long})")
   end
 
+  it 'has a valid WGS84 format' do
+    expect { Fabricate(:geolocation, lat: 'abc', long: 'abc') }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { Fabricate(:geolocation, lat: '47.0', long: '200.0') }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { Fabricate(:geolocation, lat: '99.0', long: '5.5') }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { Fabricate(:geolocation, lat: '47', long: '8.0') }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { Fabricate(:geolocation, lat: '45.1234567', long: '123.33') }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -112,6 +112,12 @@ describe Group do
         expect(group.errors.full_messages.to_sentence).to match(/Treffpunkte dürfen nicht mehr als #{limit} sein/)
       end
 
+      it 'cannot have geolocations outide of Switzerland' do
+        Fabricate(:geolocation, lat: '47.0', long: '12.0', geolocatable: group)
+        expect(group.reload).to have(1).error_on(:base)
+        expect(group.errors.full_messages.to_sentence).to match(/Diese Koordinaten liegen nicht in der Schweiz./)
+      end
+
       it 'can have group finder fields' do
         group.update!(gender: 'm', try_out_day_at: '2019-03-23')
         expect(group.reload.gender).to eq 'm'


### PR DESCRIPTION
Hackathon 2020.01

Validates the geolocations with the WGS84 decimal degree (DD) standard and makes sure the coordinates entered in the groupfinder fields are in Switzerland (approximated by a box, not exactly mapping the border).

Joint work by @Michael-Schaer and me.