### PR TITLE
Add public phone numbers to ParticipationSerializer

### DIFF
--- a/app/serializers/pbs/event_participation_serializer.rb
+++ b/app/serializers/pbs/event_participation_serializer.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::EventParticipationSerializer
+  extend ActiveSupport::Concern
+  
+  included do
+    extension(:attrs) do |_|
+      property(:phone_numbers, item.person.phone_numbers.select(&:public).map do |number| 
+        { 
+          number: number.number,
+          translated_label: number.translated_label
+        }
+      end)
+    end
+  end
+end

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -105,6 +105,7 @@ module HitobitoPbs
       PersonSerializer.send :include, Pbs::PersonSerializer
       GroupSerializer.send  :include, Pbs::GroupSerializer
       EventSerializer.send :include, Pbs::EventSerializer
+      EventParticipationSerializer.send :include, Pbs::EventParticipationSerializer
 
       ### controllers
       PeopleController.permitted_attrs += [:salutation, :title, :grade_of_school, :entry_date,

--- a/spec/serializers/pbs/event_participation_serializer_spec.rb
+++ b/spec/serializers/pbs/event_participation_serializer_spec.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+#  Copyright (c) 2019, Pfadibewegung Schweiz This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe EventParticipationSerializer do
+  let(:controller)    { double().as_null_object }
+  let(:participation) { event_participations(:top_leader) }
+  let(:serializer)    { EventParticipationSerializer.new(participation, controller) }
+  let(:hash)          { serializer.to_hash.with_indifferent_access }
+  let(:number)        { '+41 75 000 00 00' }
+
+  subject { hash[:event_participations].first }
+
+  it 'includes phone numbers' do
+    participation.person.phone_numbers.create(number: number, public: true, translated_label: 'Natel')
+
+    expect(subject[:phone_numbers]).to eq([{ 'number' => number, 'translated_label' => 'Natel' }])
+  end
+end


### PR DESCRIPTION
Vorab: @Michael-Schaer und @Team Midata: wie seht ihr diesen PR? Ist das für euch in Ordnung so?

Für das Bundeslager wurde der EventParticipationSerializer bereits um alle ```PUBLIC_ATTRS``` erweitert, um mehr oder weniger dieselben Felder auf der JSON Schnittstelle wie im CSV/Excel export zu haben. Bislang fehlen aber noch die Telefonnummern der angemeldeten Personen in eben diesem JSON.

Ich habe deshalb den ```ParticipationSerializer``` mit allen Telefonnummern einer angemeldeten Person erweitert, die als **"öffentlich"** markiert wurden. Im PBS Wagon deshalb, weil ich nicht weiss ob das für alle Wagons passen könnte.

Rückmeldungen technischer oder inhaltlicher natur sind also herzlich willkommen: @Michael-Schaer @lukaseisenring @carlobeltrame 