### PR TITLE
Elternrat stärken (Z-21)

### DIFF
--- a/app/models/group/abteilung.rb
+++ b/app/models/group/abteilung.rb
@@ -185,6 +185,10 @@ class Group::Abteilung < Group
     self.permissions = [:group_read]
   end
 
+  class PraesidiumElternrat < ::Role
+    self.permissions = [:group_read]
+  end
+
   class Redaktor < ::Role
     self.permissions = [:layer_and_below_read, :contact_data]
   end
@@ -253,6 +257,7 @@ class Group::Abteilung < Group
         Praesidium,
         VizePraesidium,
         PraesidiumApv,
+        PraesidiumElternrat,
         Praeses,
         Beisitz,
         Materialwart,

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -635,6 +635,10 @@ de:
         one: Präsident APV
         other: Präsidenten APV
         description:
+      group/abteilung/praesidium_elternrat:
+        one: Präsident*in Elternrat
+        other: Präsident*innen Elternrat
+        description:
       group/abteilung/praeses:
         one: Präses
         other: Präses


### PR DESCRIPTION
### Absicht

Es soll eine neue Rolle «Präsidium Elternrat» auf Abteilungsebene geschaffen werden, die Lese-Berechtigung auf Personen der Abteilung und Anlässe aller Art hat. Die Berechtigung der Rolle kann analog Präsidium APV umgesetzt werden.

### Lösungsvorschlag

Der PR fügt eine neue Rolle `Group::Abteilung::PraesidiumElternrat` mit `:group_read`-Permissions hinzu. Die deutsche Übersetzung ist vorhanden, weitere Übersetzungen nicht.  

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/s1QfDj1R/17-midata-z-21-elternrat-st%C3%A4rken)
* [Diskussion im Trello «Team MiData Features»](https://trello.com/c/4oOqXRja/224-elternrat-und-apv-rollen-und-gruppentypen)