### PR TITLE
API-Zugriff auf Abos und Abonnent*innen, PBS-spezifische Felder (Z-30)

### DIFF
--- a/app/serializers/pbs/mailing_list_serializer.rb
+++ b/app/serializers/pbs/mailing_list_serializer.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::MailingListSerializer
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :subscribers_includes, :kantonalverband
+  end
+
+  def subscribers_includes_with_kantonalverband
+    subscribers_includes_without_kantonalverband + [:kantonalverband]
+  end
+
+end

--- a/app/serializers/pbs/mailing_list_subscriber_serializer.rb
+++ b/app/serializers/pbs/mailing_list_subscriber_serializer.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::MailingListSubscriberSerializer
+  extend ActiveSupport::Concern
+
+  included do
+    schema do
+      property :correspondence_language, item.correspondence_language
+      property :kantonalverband_short_name, item.kantonalverband.short_name
+    end
+  end
+end


### PR DESCRIPTION
### Absicht

Auf Abos und Abonnent*innen soll per API zugegriffen werden können. Dies soll unter anderem ermöglichen, dass weitere Versandmöglichkeiten / externe Mailanbieter integriert werden können.
👉 @diegosteiner 

### Lösungsvorschlag

Dieser PR basiert auf dem [Core-PR #963](https://github.com/hitobito/hitobito/pull/963) und ergänzt die neuen Serializers um PBS-spezifische Felder.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/6EosZKkI/28-midata-z-30-schnittstellen-erweitern-api-f%C3%BCr-abos-und-abonnentinnen)
* [Diskussion im Trello «Team MiData Features»](https://trello.com/c/h5vyzHc6/107-schnittstellen-erweitern)
* Core-Issue [#242](https://github.com/hitobito/hitobito/issues/242)