### PR TITLE
Wagon-spezifische Hilfetexte (Z-23)

### DIFF
--- a/app/helpers/events_pbs_helper.rb
+++ b/app/helpers/events_pbs_helper.rb
@@ -220,7 +220,7 @@ module EventsPbsHelper
       html_options[:disabled] = 'disabled'
       html_options[:title] = t('event/camp.checkpoint_field_caption')
     end
-    f.boolean_field(attr, html_options)
+    f.boolean_field(attr, html_options) + f.render_help_text(attr)
   end
 
   def campy_al_caption(entry, short_version = false)

--- a/app/views/events/_fields_pbs.html.haml
+++ b/app/views/events/_fields_pbs.html.haml
@@ -32,9 +32,11 @@
                                                :j_s_security_mountain,
                                                :j_s_security_water)
   - if j_s_security_attrs.present?
-    = f.labeled(:j_s_security) do
+    = f.labeled(:j_s_security, nil, nil, style: "padding-top: 5px") do
       - j_s_security_attrs.each do |attr|
-        = f.boolean_field(attr, { caption: Event.human_attribute_name(attr) })
+        %div
+          = f.boolean_field(attr, { caption: Event.human_attribute_name(attr) })
+          = f.render_help_text(attr)
 
   = render 'expected_participants_fields', f: f
 


### PR DESCRIPTION
### Absicht

Für alle (Wagon-spezifischen) Felder soll es möglich sein, Hilfetexte zu erfassen (Core-Issue [#931](https://github.com/hitobito/hitobito/issues/931)).

### Lösungsvorschlag

Dieser PR basiert auf [Core-PR #967](https://github.com/hitobito/hitobito/pull/967) und benutzt die dort extrahierte Methode `render_help_text(attr)`, um Hilfetexte bei den Checkboxen «Kontrolle Lagerleitung» und J+S-«Sicherheitsbereichen» anzuzeigen.

### Verknüpfungen

* Core-Issue [#931](https://github.com/hitobito/hitobito/issues/931)
* [Issue im Trello «MiData Development»](https://trello.com/c/wPCdANW8/19-midata-z-23-hilfetexte-pbs-spezifische-felder)
* [Issue um Trello «Team MiData Features»](https://trello.com/c/26D65dax/255-kontexthilfe-hilfetexte-pbs-spezifische-felder-kompatibel-machen)