### PR TITLE
Events: «Lagerleitung» als «Hauptleitung» exportieren (Z)

### DIFF
--- a/app/domain/pbs/export/tabular/events/row.rb
+++ b/app/domain/pbs/export/tabular/events/row.rb
@@ -11,11 +11,16 @@ module Pbs::Export::Tabular::Events
 
     included do
       dynamic_attributes[/^advisor_/] = :contactable_attribute
+      alias_method_chain :leader, :pbs_restriction
     end
 
     def advisor
       # Only Event::Course provides restricted advisor role
       entry.try(:advisor)
+    end
+
+    def leader_with_pbs_restriction
+      @leader ||= entry.participations_for(Event::Camp::Role::Leader).first.try(:person)
     end
   end
 end

--- a/app/domain/pbs/export/tabular/events/row.rb
+++ b/app/domain/pbs/export/tabular/events/row.rb
@@ -11,7 +11,7 @@ module Pbs::Export::Tabular::Events
 
     included do
       dynamic_attributes[/^advisor_/] = :contactable_attribute
-      alias_method_chain :leader, :pbs_restriction
+      alias_method_chain :leader, :camp
     end
 
     def advisor
@@ -19,8 +19,13 @@ module Pbs::Export::Tabular::Events
       entry.try(:advisor)
     end
 
-    def leader_with_pbs_restriction
-      @leader ||= entry.participations_for(Event::Camp::Role::Leader).first.try(:person)
+    def leader_with_camp
+      # for reasons unknowns (86f7c17) Event::Camp::Role::Leader kind is set to nil
+      if entry.is_a?(Event::Camp)
+        entry.participations_for(Event::Camp::Role::Leader).first.try(:person)
+      else
+        leader_without_camp
+      end
     end
   end
 end

--- a/spec/domain/export/tabular/events/row_spec.rb
+++ b/spec/domain/export/tabular/events/row_spec.rb
@@ -1,0 +1,69 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe Export::Tabular::Events::Row do
+
+
+  context :course do
+    let(:event) { events(:top_course) }
+
+    describe Event::Course::Role::Leader do
+      it 'is marked as leader' do
+        expect(subject.kind).to eq :leader
+        expect(subject.class).to be_leader
+      end
+    end
+
+    describe :row do
+      let(:row) { Export::Tabular::Events::Row.new(event, :format, :state_counts, :gender_counts) }
+      subject { row.fetch(:leader_name) }
+
+      it 'includes Event::Camp::Role::Leader although role kind is nil' do
+        expect(subject).to eq "Dr. Bundes Leiter / Scout"
+      end
+
+      it 'returns other leaders even if leader participations exists' do
+        event_participations(:top_leader).destroy!
+        participation = Fabricate(:event_participation, event: event)
+        role = Fabricate(Event::Course::Role::Helper.name.to_sym, participation: participation)
+        expect(role.class).to be_leader
+        expect(subject).not_to be_nil
+      end
+    end
+  end
+
+
+  context :camp do
+    let(:event) { events(:schekka_camp) }
+    describe Event::Camp::Role::Leader do
+      it 'is not marked as leader' do
+        expect(subject.kind).to be_nil
+        expect(subject.class).not_to be_leader
+      end
+    end
+
+    describe :row do
+      let(:row) { Export::Tabular::Events::Row.new(event, :format, :state_counts, :gender_counts) }
+      subject { row.fetch(:leader_name) }
+
+      it 'includes Event::Camp::Role::Leader although role kind is nil' do
+        expect(subject).to eq "Dr. Bundes Leiter / Scout"
+      end
+
+      it 'returns nil even if other Leader Participations exists' do
+        event_participations(:schekka_camp_leader).destroy!
+        participation = Fabricate(:event_participation, event: event)
+        role = Fabricate(Event::Camp::Role::AssistantLeader.name.to_sym, participation: participation)
+        expect(role.class).to be_leader
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Im Event-Export erscheint aktuell in den Feldern «Hauptleitung» die erste Person, welche eine «Leitungs»-Rolle hat.

Dieser PR ändert dieses Verhalten für die PBS und exportiert nun in diesen Feldern die Person, welche als Lagerleitung eingetragen wurde (Tab «Betreuung»).