### PR TITLE
«Sarasani digital»: Attribut für Versandpräferenz (Z-41)

### DIFF
--- a/app/domain/pbs/export/tabular/people/households_full.rb
+++ b/app/domain/pbs/export/tabular/people/households_full.rb
@@ -10,7 +10,7 @@ module Pbs::Export::Tabular::People
 
     def person_attributes
       super +
-      [:correspondence_language, :kantonalverband_id,
+      [:correspondence_language, :prefers_digital_correspondence, :kantonalverband_id,
        :id, :layer_group_id, :company_name, :company]
     end
   end

--- a/app/domain/pbs/export/tabular/people/people_address.rb
+++ b/app/domain/pbs/export/tabular/people/people_address.rb
@@ -28,8 +28,8 @@ module Pbs
 
           def person_attributes_with_title
             person_attributes_without_title +
-            [:title, :salutation, :correspondence_language, :kantonalverband_id,
-             :id, :layer_group_id]
+            [:title, :salutation, :correspondence_language, :prefers_digital_correspondence,
+             :kantonalverband_id, :id, :layer_group_id]
           end
         end
       end

--- a/app/models/pbs/person.rb
+++ b/app/models/pbs/person.rb
@@ -56,11 +56,12 @@ module Pbs::Person
   extend ActiveSupport::Concern
 
   included do
-    Person::PUBLIC_ATTRS << :title << :salutation << :correspondence_language << :kantonalverband_id
+    Person::PUBLIC_ATTRS << :title << :salutation << :correspondence_language <<
+                            :prefers_digital_correspondence << :kantonalverband_id
 
     alias_method_chain :full_name, :title
 
-    i18n_boolean_setter :brother_and_sisters
+    i18n_boolean_setter :brother_and_sisters, :prefers_digital_correspondence
 
 
     belongs_to :kantonalverband, class_name: 'Group' # might also be Group::Bund

--- a/app/models/pbs/person.rb
+++ b/app/models/pbs/person.rb
@@ -80,6 +80,8 @@ module Pbs::Person
     validates :entry_date, :leaving_date,
               timeliness: { type: :date, allow_blank: true, before: Date.new(9999, 12, 31) }
 
+    validate :has_email_when_preferring_digital_correspondence
+
     after_create :set_pbs_number!, if: :pbs_number_column_available?
     after_save :reset_kantonalverband!, if: :primary_group_id_previously_changed?
     after_save :send_black_list_mail, if: :blacklisted_attribute_changed?
@@ -143,6 +145,12 @@ module Pbs::Person
 
   def blacklisted_attribute_changed?
     %w(first_name last_name email).any? { |k| previous_changes.key?(k) } && black_listed?
+  end
+
+  def has_email_when_preferring_digital_correspondence
+    if prefers_digital_correspondence && email.blank?
+      errors.add(:prefers_digital_correspondence, :email_must_exist)
+    end
   end
 
 end

--- a/app/serializers/pbs/person_serializer.rb
+++ b/app/serializers/pbs/person_serializer.rb
@@ -11,7 +11,8 @@ module Pbs::PersonSerializer
   included do
     extension(:details) do |_|
       map_properties :pbs_number, :salutation_value, :correspondence_language,
-                     :grade_of_school, :brother_and_sisters, :entry_date, :leaving_date
+                     :prefers_digital_correspondence, :grade_of_school, :brother_and_sisters,
+                     :entry_date, :leaving_date
     end
   end
 

--- a/app/views/people/_details_pbs.html.haml
+++ b/app/views/people/_details_pbs.html.haml
@@ -4,7 +4,6 @@
 -#  https://github.com/hitobito/hitobito_pbs.
 
 = render_attrs(entry, :pbs_number, :salutation, :correspondence_language,
-                      :grade_of_school, :brother_and_sisters)
+                      :prefers_digital_correspondence, :grade_of_school, :brother_and_sisters)
 
 = render_attrs(entry, :entry_date, :leaving_date)
-

--- a/app/views/people/_fields_pbs.html.haml
+++ b/app/views/people/_fields_pbs.html.haml
@@ -12,6 +12,7 @@
                                 :last,
                                 { prompt: true },
                                 class: 'span6')
+  = f.labeled_boolean_field :prefers_digital_correspondence
   = f.labeled_input_field :grade_of_school, help_inline: t('.non_automatic_field')
 
 = field_set_tag do

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1201,6 +1201,10 @@ de:
           attributes:
             base:
               cannot_remove_parent_id: "Das übergeordnete Lager kann nicht mehr verlassen werden, da es nicht mehr im Status \"Erstellt\" ist"
+        person:
+          attributes:
+            prefers_digital_correspondence:
+              email_must_exist: Für digitale Versandpräferenz muss die Haupt-E-Mail existieren
         role:
           attributes:
             created_at:

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1113,6 +1113,7 @@ de:
         brother_and_sisters: Geschwister
         relations_to_tails: Geschwister
         kv: Kantonalverband
+        prefers_digital_correspondence: Digitale Korrespondenz bevorzugt
 
       group:
         pta: PTA

--- a/db/migrate/20200623000000_add_correspondence_preference_to_person.rb
+++ b/db/migrate/20200623000000_add_correspondence_preference_to_person.rb
@@ -8,5 +8,6 @@
 class AddCorrespondencePreferenceToPerson < ActiveRecord::Migration[6.0]
   def change
     add_column :people, :prefers_digital_correspondence, :boolean, null: false, default: false
+    Person.reset_column_information
   end
 end

--- a/db/migrate/20200623000000_add_correspondence_preference_to_person.rb
+++ b/db/migrate/20200623000000_add_correspondence_preference_to_person.rb
@@ -5,7 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
 
-class AddCorrespondencePreferenceToPerson < ActiveRecord::Migration[4.2]
+class AddCorrespondencePreferenceToPerson < ActiveRecord::Migration[6.0]
   def change
     add_column :people, :prefers_digital_correspondence, :boolean, null: false, default: false
   end

--- a/db/migrate/20200623000000_add_correspondence_preference_to_person.rb
+++ b/db/migrate/20200623000000_add_correspondence_preference_to_person.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class AddCorrespondencePreferenceToPerson < ActiveRecord::Migration[4.2]
+  def change
+    add_column :people, :prefers_digital_correspondence, :boolean, null: false, default: false
+  end
+end

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -106,7 +106,7 @@ module HitobitoPbs
       ### controllers
       PeopleController.permitted_attrs += [:salutation, :title, :grade_of_school, :entry_date,
                                            :leaving_date, :j_s_number, :correspondence_language,
-                                           :brother_and_sisters]
+                                           :prefers_digital_correspondence, :brother_and_sisters]
       Event::KindsController.permitted_attrs += [:documents_text, :campy, :can_have_confirmations,
                                                  :confirmation_name]
       QualificationKindsController.permitted_attrs += [:manual]

--- a/spec/domain/export/tabular/people/households_spec.rb
+++ b/spec/domain/export/tabular/people/households_spec.rb
@@ -19,8 +19,8 @@ describe Pbs::Export::Tabular::People::HouseholdsFull do
     it 'includes name, address attributes and layer group columns' do
       expect(households.attributes).to eq [:name, :address, :zip_code, :town,
                                            :country, :layer_group, :correspondence_language,
-                                           :kantonalverband_id, :id, :layer_group_id,
-                                           :company_name, :company]
+                                           :prefers_digital_correspondence, :kantonalverband_id,
+                                           :id, :layer_group_id, :company_name, :company]
     end
   end
 

--- a/spec/domain/export/tabular/people/people_address_spec.rb
+++ b/spec/domain/export/tabular/people/people_address_spec.rb
@@ -13,7 +13,8 @@ describe Export::Tabular::People::PeopleAddress do
   let(:person) { people(:bulei) }
   let(:simple_headers) do
     %w(Vorname Nachname Pfadiname Firmenname Firma Haupt-E-Mail Adresse PLZ Ort Land
-       Geschlecht Geburtstag Hauptebene Rollen Tags Titel Anrede Korrespondenzsprache Kantonalverband Id) << 'Id der Hauptebene'
+       Geschlecht Geburtstag Hauptebene Rollen Tags Titel Anrede Korrespondenzsprache
+       Digitale\ Korrespondenz\ bevorzugt Kantonalverband Id) << 'Id der Hauptebene'
   end
   let(:list) { Person.where(id: person) }
   let(:data) { Export::Tabular::People::PeopleAddress.csv(list) }

--- a/spec/domain/export/tabular/people/people_full_spec.rb
+++ b/spec/domain/export/tabular/people/people_full_spec.rb
@@ -22,7 +22,7 @@ describe Export::Tabular::People::PeopleFull do
      :ahv_number, :j_s_number, :salutation, :title, :grade_of_school,
      :entry_date, :leaving_date, :correspondence_language,
      :brother_and_sisters, :kantonalverband_id,
-     :pbs_number, :layer_group,
+     :pbs_number, :prefers_digital_correspondence, :layer_group,
      :roles, :tags, :id, :layer_group_id]
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -74,6 +74,30 @@ describe Person do
       expect(person).to have(1).error_on(:salutation)
     end
 
+    context 'prefers_digital_correspondence' do
+      it 'succeeds when preferring physical correspondence and having an email address' do
+        person.prefers_digital_correspondence = false
+        expect(person).to be_valid
+      end
+
+      it 'succeeds when preferring physical correspondence and not having an email address' do
+        person.email = nil
+        person.prefers_digital_correspondence = false
+        expect(person).to be_valid
+      end
+
+      it 'succeeds when preferring digital correspondence and having an email address' do
+        person.prefers_digital_correspondence = true
+        expect(person).to be_valid
+      end
+
+      it 'fails when preferring digital correspondence and not having an email address' do
+        person.email = nil
+        person.prefers_digital_correspondence = true
+        expect(person).to have(1).error_on(:prefers_digital_correspondence)
+      end
+    end
+
   end
 
   context '#salutation_value' do


### PR DESCRIPTION
### Absicht

Für Versände in digitalen und analogen Fassungen soll es Personen möglich sein, ihre «Versandpräferenz» (entweder digital oder print) zu speichern, damit sie gezielt angeschrieben werden können. 

### Lösungsvorschlag

Dieser PR fügt dem Person-Model ein neues Attribut `prefers_digital_correspondence` hinzu:
* standardmässig falsch (= print bevorzugt), muss ausgefüllt werden
* wechseln auf digital validiert die Existenz einer Emailadresse
* wird bei gängigen Exporten eingeschlossen

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/rlxnzcNx/23-midata-z-41-sarasani-digital)
* [Issue im Trello «Team MiData Features»](https://trello.com/c/gMp4HM2X/229-sarasani-digital)