### PR TITLE
Notfallnummer im Lager-Export (Z-44)

### DIFF
--- a/app/domain/pbs/export/tabular/events/list.rb
+++ b/app/domain/pbs/export/tabular/events/list.rb
@@ -34,6 +34,7 @@ module Pbs::Export::Tabular::Events::List
   end
 
   def add_contact_labels_with_advisor(labels)
+    add_used_attribute_label(labels, :emergency_phone)
     add_contact_labels_without_advisor(labels)
     if attr_used?(:advisor_id)
       add_prefixed_contactable_labels(labels, :advisor)

--- a/spec/domain/export/csv/events/list_spec.rb
+++ b/spec/domain/export/csv/events/list_spec.rb
@@ -154,7 +154,7 @@ describe Export::Tabular::Events::List do
       subject { csv.first }
       it {
         is_expected.to eq <<-CSV_HEADERS.chomp
-Name;Organisatoren;Beschreibung;Lagerstatus;Ort / Adresse;Datum 1 Bezeichnung;Datum 1 Ort;Datum 1 Zeitraum;Datum 2 Bezeichnung;Datum 2 Ort;Datum 2 Zeitraum;Datum 3 Bezeichnung;Datum 3 Ort;Datum 3 Zeitraum;Kontaktperson Name;Kontaktperson Adresse;Kontaktperson PLZ;Kontaktperson Ort;Kontaktperson Haupt-E-Mail;Kontaktperson Telefonnummern;Hauptleitung Name;Hauptleitung Adresse;Hauptleitung PLZ;Hauptleitung Ort;Hauptleitung Haupt-E-Mail;Hauptleitung Telefonnummern;Motto;Kosten;Anmeldebeginn;Anmeldeschluss;Maximale Teilnehmerzahl;Externe Anmeldungen;J+S-Rahmen;Kanton / Land;Eingereicht;Eingereicht am;Leitungsteam erwartet;Teilnehmende erwartet;Anzahl Leitungsteam;Anzahl Teilnehmende;Anzahl Anmeldungen
+Name;Organisatoren;Beschreibung;Lagerstatus;Ort / Adresse;Datum 1 Bezeichnung;Datum 1 Ort;Datum 1 Zeitraum;Datum 2 Bezeichnung;Datum 2 Ort;Datum 2 Zeitraum;Datum 3 Bezeichnung;Datum 3 Ort;Datum 3 Zeitraum;Notfallnummer;Kontaktperson Name;Kontaktperson Adresse;Kontaktperson PLZ;Kontaktperson Ort;Kontaktperson Haupt-E-Mail;Kontaktperson Telefonnummern;Hauptleitung Name;Hauptleitung Adresse;Hauptleitung PLZ;Hauptleitung Ort;Hauptleitung Haupt-E-Mail;Hauptleitung Telefonnummern;Motto;Kosten;Anmeldebeginn;Anmeldeschluss;Maximale Teilnehmerzahl;Externe Anmeldungen;J+S-Rahmen;Kanton / Land;Eingereicht;Eingereicht am;Leitungsteam erwartet;Teilnehmende erwartet;Anzahl Leitungsteam;Anzahl Teilnehmende;Anzahl Anmeldungen
         CSV_HEADERS
       }
     end


### PR DESCRIPTION
### Absicht

> Das Krisenteam würde es begrüssen, wenn die Notfallnummer ebenfalls im Lager-Export vorhanden ist.

### Lösungsvorschlag

Dieser PR fügt dem Events-Export das Feld `emergency_phone` hinzu.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/85YQ3Qsm/46-midata-z-44-notfallnummer-in-der-lagerliste)