### PR TITLE
Fix: Request course approvals when changing the rules on a course

### DIFF
--- a/app/domain/event/approver.rb
+++ b/app/domain/event/approver.rb
@@ -76,8 +76,11 @@ class Event::Approver
   end
 
   def request_approval(layer_name)
-    application.approvals.create!(layer: layer_name)
-    send_approval_request
+    approval = application.approvals.where(layer: layer_name)
+    unless approval.exists?
+      approval.create!
+      send_approval_request
+    end
   end
 
   def update_approval(approved, attrs, user)

--- a/app/domain/event/approver.rb
+++ b/app/domain/event/approver.rb
@@ -14,7 +14,7 @@ class Event::Approver
     @participation = participation
   end
 
-  def application_created
+  def request_approvals
     return unless primary_group && application
 
     layer_name = next_approval_layer

--- a/app/models/pbs/event/application.rb
+++ b/app/models/pbs/event/application.rb
@@ -25,7 +25,7 @@ module Pbs::Event::Application
   def initialize_approval
     if participation.present?
       approver = Event::Approver.new(participation.reload)
-      approver.application_created
+      approver.request_approvals
     end
   end
 

--- a/app/models/pbs/event/course.rb
+++ b/app/models/pbs/event/course.rb
@@ -83,7 +83,7 @@ module Pbs::Event::Course
   end
 
   def request_missing_approvals
-    if APPROVALS.any? { |approval_attr| saved_changes_to_attr? approval_attr.to_sym }
+    if APPROVALS.any? { |approval_attr| saved_changes_to_attribute? approval_attr.to_sym }
       participations.each do |participation|
         Event::Approver.new(participation).request_approvals
       end

--- a/app/models/pbs/event/course.rb
+++ b/app/models/pbs/event/course.rb
@@ -83,7 +83,7 @@ module Pbs::Event::Course
   end
 
   def request_missing_approvals
-    if APPROVALS.any? { |approval_attr| saved_changes_to_attribute? approval_attr.to_sym }
+    if APPROVALS.any? { |approval_attr| saved_change_to_attribute? approval_attr.to_sym }
       participations.each do |participation|
         Event::Approver.new(participation).request_approvals
       end

--- a/app/models/pbs/event/course.rb
+++ b/app/models/pbs/event/course.rb
@@ -44,6 +44,7 @@ module Pbs::Event::Course
     after_initialize :become_campy
     before_save :set_requires_approval
     before_save :set_globally_visible
+    after_save :request_missing_approvals
   end
 
 
@@ -79,6 +80,14 @@ module Pbs::Event::Course
 
   def set_globally_visible
     self.globally_visible = true
+  end
+
+  def request_missing_approvals
+    if APPROVALS.any? { |approval_attr| saved_changes_to_attr? approval_attr.to_sym }
+      participations.each do |participation|
+        Event::Approver.new(participation).request_approvals
+      end
+    end
   end
 
   def assert_bsv_days_precision

--- a/spec/domain/event/approver_spec.rb
+++ b/spec/domain/event/approver_spec.rb
@@ -76,7 +76,7 @@ describe Event::Approver do
       end
 
       it 'creates no Event::Approval and sends no emails if participation has no application' do
-        approver.application_created
+        approver.request_approvals
         expect(Event::Approval.count).to eq(0)
         expect(Event::ParticipationMailer).to_not have_received(:approval)
       end

--- a/spec/models/event/application_spec.rb
+++ b/spec/models/event/application_spec.rb
@@ -55,8 +55,8 @@ describe Event::Application do
       course.update(requires_approval_abteilung: true)
     end
 
-    it 'changing approval requirement on prio 2 course calls Event::Approver.request_approvals' do
-      expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
+    it 'changing approval requirement on prio 2 course does not call Event::Approver.request_approvals' do
+      expect_any_instance_of(Event::Approver).not_to receive(:request_approvals)
       course2.update(requires_approval_abteilung: true)
     end
   end

--- a/spec/models/event/application_spec.rb
+++ b/spec/models/event/application_spec.rb
@@ -24,18 +24,36 @@ describe Event::Application do
           end
         end
 
-        it 'calls Event::Approver.application_created on creation' do
-          expect_any_instance_of(Event::Approver).to receive(:application_created).once
+        it 'calls Event::Approver.request_approvals on creation' do
+          expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
           Fabricate(:event_application, priority_1: course, priority_2: course2,
                                         participation: participation)
         end
 
-        it 'does not call Event::Approver.application_create on update' do
-          expect_any_instance_of(Event::Approver).to receive(:application_created).once
+        it 'does not call Event::Approver.request_approvals on update' do
+          expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
           application = Fabricate(:event_application, priority_1: course,
                                                       priority_2: course2,
                                                       participation: participation)
           application.save!
+        end
+
+        it 'calls Event::Approver.request_approvals when prio 1 course changes the approval flag' do
+          course.update(requires_approval_abteilung: false)
+
+          expect_any_instance_of(Event::Approver).to receive(:request_approvals).twice
+          Fabricate(:event_application, priority_1: course, priority_2: course2,
+                    participation: participation)
+          course.update(requires_approval_abteilung: true)
+        end
+
+        it 'calls Event::Approver.request_approvals when prio 2 course changes the approval flag' do
+          course2.update(requires_approval_abteilung: false)
+
+          expect_any_instance_of(Event::Approver).to receive(:request_approvals).twice
+          Fabricate(:event_application, priority_1: course, priority_2: course2,
+                    participation: participation)
+          course2.update(requires_approval_abteilung: true)
         end
       end
     end

--- a/spec/models/event/application_spec.rb
+++ b/spec/models/event/application_spec.rb
@@ -11,52 +11,49 @@ describe Event::Application do
 
   let(:course) { Fabricate(:course, groups: [groups(:schekka)], kind: event_kinds(:lpk)) }
   let(:course2) { Fabricate(:course, groups: [groups(:schekka)], kind: event_kinds(:lpk)) }
+  let(:participation) { Fabricate(:pbs_participation, person: people(:al_schekka)) }
 
-  describe 'approval' do
-    let(:participation) { Fabricate(:pbs_participation, person: people(:al_schekka)) }
-
-    [true, false].each do |requires_approval|
-      context requires_approval && 'required' || 'not required' do
-        before do
-          if requires_approval
-            course.requires_approval_abteilung = requires_approval
-            course.save!
-          end
-        end
-
-        it 'calls Event::Approver.request_approvals on creation' do
-          expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
-          Fabricate(:event_application, priority_1: course, priority_2: course2,
-                                        participation: participation)
-        end
-
-        it 'does not call Event::Approver.request_approvals on update' do
-          expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
-          application = Fabricate(:event_application, priority_1: course,
-                                                      priority_2: course2,
-                                                      participation: participation)
-          application.save!
-        end
-
-        it 'calls Event::Approver.request_approvals when prio 1 course changes the approval flag' do
-          course.update(requires_approval_abteilung: false)
-
-          expect_any_instance_of(Event::Approver).to receive(:request_approvals).twice
-          Fabricate(:event_application, priority_1: course, priority_2: course2,
-                    participation: participation)
-          course.update(requires_approval_abteilung: true)
-        end
-
-        it 'calls Event::Approver.request_approvals when prio 2 course changes the approval flag' do
-          course2.update(requires_approval_abteilung: false)
-
-          expect_any_instance_of(Event::Approver).to receive(:request_approvals).twice
-          Fabricate(:event_application, priority_1: course, priority_2: course2,
-                    participation: participation)
-          course2.update(requires_approval_abteilung: true)
+  [true, false].each do |requires_approval|
+    context requires_approval && 'approval required' || 'approval not required' do
+      before do
+        if requires_approval
+          course.requires_approval_abteilung = requires_approval
+          course.save!
         end
       end
+
+      it 'calls Event::Approver.request_approvals on creation' do
+        expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
+        Fabricate(:event_application, priority_1: course, priority_2: course2,
+                                      participation: participation)
+      end
+
+      it 'does not call Event::Approver.request_approvals on update' do
+        expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
+        application = Fabricate(:event_application, priority_1: course,
+                                                    priority_2: course2,
+                                                    participation: participation)
+        application.save!
+      end
     end
+  end
+
+  it 'changing approval requirement on prio 1 course calls Event::Approver.request_approvals' do
+    course.update(requires_approval_abteilung: false)
+
+    expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
+    Fabricate(:event_application, priority_1: course, priority_2: course2,
+              participation: participation)
+    course.update(requires_approval_abteilung: true)
+  end
+
+  it 'changing approval requirement on prio 2 course calls Event::Approver.request_approvals' do
+    course2.update(requires_approval_abteilung: false)
+
+    expect_any_instance_of(Event::Approver).to receive(:request_approvals).once
+    Fabricate(:event_application, priority_1: course, priority_2: course2,
+              participation: participation)
+    course2.update(requires_approval_abteilung: true)
   end
 
 end


### PR DESCRIPTION
Scenario:
1. I create a course and accidentally leave the `requires_approval_abteilung`, `requires_approval_region` etc. flags unchecked.
2. Some participant p1 applies for the course
3. I notice my error, edit the course and activate the flag `requires_approval_abteilung`
4. Some other participant p2 applies for the course

Then, the approval of the Abteilung will be requested normally for p2, but no approval will ever be requested for p1.

This PR fixes this problem, by checking and sending out missing approvals (i.e. creating the approval objects in the database and sending the email), whenever the course's `require_approval_*` flags are changed.

@Michael-Schaer please test this and discuss with the AKom whether this is a useful fix. We had this issue in several of our courses this year.