### PR TITLE
Sichtbarkeit von Anlässen (und so), PBS-Edition

### DIFF
--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -1,4 +1,6 @@
-#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -76,6 +78,11 @@ module Pbs::EventAbility
     end
 
     alias_method_chain :if_full_permission_in_course_layer, :ausbildungskommission
+    alias_method_chain :if_globally_visible_or_participating, :pbs
+  end
+
+  def if_globally_visible_or_participating_with_pbs
+    if_globally_visible_or_participating_without_pbs || participating?
   end
 
   def for_advised_courses

--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -82,7 +82,9 @@ module Pbs::EventAbility
   end
 
   def if_globally_visible_or_participating_with_pbs
-    if_globally_visible_or_participating_without_pbs || participating?
+    if_globally_visible_or_participating_without_pbs ||
+      participating? ||
+      if_part_of_krisenteam
   end
 
   def for_advised_courses

--- a/app/models/group/abteilung.rb
+++ b/app/models/group/abteilung.rb
@@ -2,6 +2,7 @@
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
+
 # == Schema Information
 #
 # Table name: groups

--- a/app/models/group/bund.rb
+++ b/app/models/group/bund.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -98,7 +98,7 @@ class Group::Bund < Group
   end
 
   class GrossanlassCoach < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class InternationalCommissionerIcWagggs < ::Role
@@ -139,7 +139,7 @@ class Group::Bund < Group
   end
 
   class Mediensprecher < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class Mitarbeiter < ::Role
@@ -154,9 +154,8 @@ class Group::Bund < Group
     self.permissions = [:layer_and_below_full, :contact_data, :admin, :impersonation]
   end
 
-
   class MitgliedKrisenteam < ::Role
-    self.permissions = [:group_read, :contact_data, :crisis_trigger]
+    self.permissions = [:layer_and_below_read, :contact_data, :crisis_trigger]
   end
 
   class Passivmitglied < ::Role

--- a/app/models/group/kantonalverband.rb
+++ b/app/models/group/kantonalverband.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -119,11 +119,11 @@ class Group::Kantonalverband < Group
   end
 
   class Leitungskursbetreuung < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class Mediensprecher < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class Mitarbeiter < ::Role
@@ -131,7 +131,7 @@ class Group::Kantonalverband < Group
   end
 
   class MitgliedKrisenteam < ::Role
-    self.permissions = [:group_read, :contact_data, :crisis_trigger]
+    self.permissions = [:layer_and_below_read, :contact_data, :crisis_trigger]
   end
 
   class Krisenverantworlicher < ::Role
@@ -184,7 +184,7 @@ class Group::Kantonalverband < Group
   end
 
   class VerantwortungBetreuung < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class VerantwortungBiberstufe < ::Role
@@ -208,11 +208,11 @@ class Group::Kantonalverband < Group
   end
 
   class VerantwortungKrisenteam < ::Role
-    self.permissions = [:group_read, :contact_data, :crisis_trigger]
+    self.permissions = [:layer_and_below_read, :contact_data, :crisis_trigger]
   end
 
   class VerantwortungLagermeldung < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class VerantwortungLagerplaetze < ::Role

--- a/app/models/group/region.rb
+++ b/app/models/group/region.rb
@@ -4,6 +4,7 @@
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
+
 # == Schema Information
 #
 # Table name: groups

--- a/app/models/group/region.rb
+++ b/app/models/group/region.rb
@@ -79,7 +79,6 @@ class Group::Region < Group
   class Adressverwaltung < ::Role
     self.permissions = [:layer_and_below_full]
   end
-  class PowerUser < Adressverwaltung; end
 
   class Beisitz < ::Role
     self.permissions = [:group_read]
@@ -121,6 +120,9 @@ class Group::Region < Group
   class Passivmitglied < ::Role
     self.permissions = []
     self.kind = :passive
+  end
+
+  class PowerUser < Adressverwaltung
   end
 
   class Praeses < ::Role

--- a/app/models/group/region.rb
+++ b/app/models/group/region.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -102,11 +102,11 @@ class Group::Region < Group
   end
 
   class Leitungskursbetreuung < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class Mediensprecher < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class Mitarbeiter < ::Role
@@ -114,7 +114,7 @@ class Group::Region < Group
   end
 
   class MitgliedKrisenteam < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class Passivmitglied < ::Role
@@ -167,7 +167,7 @@ class Group::Region < Group
   end
 
   class VerantwortungBetreuung < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class VerantwortungBiberstufe < ::Role
@@ -187,11 +187,11 @@ class Group::Region < Group
   end
 
   class VerantwortungKrisenteam < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class VerantwortungLagermeldung < ::Role
-    self.permissions = [:group_read, :contact_data]
+    self.permissions = [:layer_and_below_read, :contact_data]
   end
 
   class VerantwortungLagerplaetze < ::Role

--- a/app/models/pbs/event/course.rb
+++ b/app/models/pbs/event/course.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -21,7 +21,7 @@ module Pbs::Event::Course
                             APPROVALS.collect(&:to_sym)
     self.used_attributes -= [:requires_approval, :j_s_kind, :canton, :camp_submitted,
                              :camp_submitted_at, :total_expected_leading_participants,
-                             :total_expected_participants]
+                             :total_expected_participants, :globally_visible]
 
     self.superior_attributes = [:express_fee, :training_days]
 
@@ -43,6 +43,7 @@ module Pbs::Event::Course
     ### CALLBACKS
     after_initialize :become_campy
     before_save :set_requires_approval
+    before_save :set_globally_visible
   end
 
 
@@ -74,6 +75,10 @@ module Pbs::Event::Course
       requires_approval_bund?
 
     true
+  end
+
+  def set_globally_visible
+    self.globally_visible = true
   end
 
   def assert_bsv_days_precision

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,8 @@ email:
     submit_recipient: lager@pbs.ch
     submit_abroad_recipient: auslandlager@pbs.ch
 
+event:
+  globally_visible_by_default: false
 
 people:
   abos: true

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 #  Copyright (c) 2012-2019, Pfadibewegung Schweiz. This file is part of
@@ -22,92 +21,74 @@ module HitobitoPbs
     config.to_prepare do # rubocop:disable Metrics/BlockLength
 
       ### models
-      Group.send         :include, Pbs::Group
-      Person.send        :include, Pbs::Person
-      Role.send          :include, Pbs::Role
-      Qualification.send :include, Pbs::Qualification
-      Event.send         :include, Pbs::Event
-      Event::Kind.send   :include, Pbs::Event::Kind
-      Event::Course.send :include, Pbs::Event::Course
-      Event::Participation.send :include, Pbs::Event::Participation
-      Event::ParticipationContactData.send :include, Pbs::Event::ParticipationContactData
-      Event::Application.send :include, Pbs::Event::Application
-      ServiceToken.send :include, Pbs::ServiceToken
+      Group.include Pbs::Group
+      Person.include Pbs::Person
+      Role.include Pbs::Role
+      Qualification.include Pbs::Qualification
+      Event.include Pbs::Event
+      Event::Kind.include Pbs::Event::Kind
+      Event::Course.include Pbs::Event::Course
+      Event::Participation.include Pbs::Event::Participation
+      Event::ParticipationContactData.include Pbs::Event::ParticipationContactData
+      Event::Application.include Pbs::Event::Application
+      ServiceToken.include Pbs::ServiceToken
 
       Event.acts_as_nested_set(dependent: :nullify)
 
       PeopleRelation.kind_opposites['sibling'] = 'sibling'
-      PhoneNumber.send :include, Pbs::PhoneNumber
+      PhoneNumber.include Pbs::PhoneNumber
 
       ## domain
       Bsv::Info.leader_roles += [Event::Course::Role::Helper]
       Export::Pdf::Participation.runner = Pbs::Export::Pdf::Participation::Runner
-      Event::ParticipantAssigner.send :include, Pbs::Event::ParticipantAssigner
-      Event::Filter.send :include, Pbs::Event::Filter
-      Event::Qualifier.send :include, Pbs::Event::Qualifier
-      Export::Tabular::Events::List.send :include, Pbs::Export::Tabular::Events::List
-      Export::Tabular::Events::Row.send :include, Pbs::Export::Tabular::Events::Row
-      Export::Tabular::People::ParticipationsFull.send(
-        :include, Pbs::Export::Tabular::People::ParticipationsFull
-      )
-      Export::Tabular::People::ParticipationRow.send(
-        :include, Pbs::Export::Tabular::People::ParticipationRow
-      )
-      Export::Tabular::People::ParticipationNdbjsRow.send(
-        :include, Pbs::Export::Tabular::People::ParticipationNdbjsRow
-      )
-      Export::Tabular::People::PersonRow.send(
-        :include, Pbs::Export::Tabular::People::PersonRow
-      )
-      Export::Tabular::People::PeopleAddress.send(
-        :include, Pbs::Export::Tabular::People::PeopleAddress
-      )
-      Export::Tabular::People::PeopleFull.send(
-        :include, Pbs::Export::Tabular::People::PeopleFull
-      )
-      Export::Tabular::Events::BsvRow.send :include, Pbs::Export::Tabular::Events::BsvRow
-      Export::PeopleExportJob.send(
-       :include, Pbs::Export::PeopleExportJob
-      )
-      Export::EventParticipationsExportJob.send(
-        :include, Pbs::Export::EventParticipationsExportJob
-      )
-      Export::SubscriptionsJob.send(
-        :include, Pbs::Export::SubscriptionsJob
-      )
+      Event::ParticipantAssigner.include Pbs::Event::ParticipantAssigner
+      Event::Filter.include Pbs::Event::Filter
+      Event::Qualifier.include Pbs::Event::Qualifier
+      Export::Tabular::Events::List.include Pbs::Export::Tabular::Events::List
+      Export::Tabular::Events::Row.include Pbs::Export::Tabular::Events::Row
+      Export::Tabular::People::ParticipationsFull.include Pbs::Export::Tabular::People::ParticipationsFull
+      Export::Tabular::People::ParticipationRow.include Pbs::Export::Tabular::People::ParticipationRow
+      Export::Tabular::People::ParticipationNdbjsRow.include Pbs::Export::Tabular::People::ParticipationNdbjsRow
+      Export::Tabular::People::PersonRow.include Pbs::Export::Tabular::People::PersonRow
+      Export::Tabular::People::PeopleAddress.include Pbs::Export::Tabular::People::PeopleAddress
+      Export::Tabular::People::PeopleFull.include Pbs::Export::Tabular::People::PeopleFull
+      Export::Tabular::Events::BsvRow.include Pbs::Export::Tabular::Events::BsvRow
+      Export::PeopleExportJob.include Pbs::Export::PeopleExportJob
+      Export::EventParticipationsExportJob.include Pbs::Export::EventParticipationsExportJob
+      Export::SubscriptionsJob.include Pbs::Export::SubscriptionsJob
 
       ### abilities
       Ability.store.register Event::ApprovalAbility
       AbilityDsl::UserContext::GROUP_PERMISSIONS << :crisis_trigger
       AbilityDsl::UserContext::LAYER_PERMISSIONS << :crisis_trigger
-      GroupAbility.send :include, Pbs::GroupAbility
-      PersonReadables.send :include, Pbs::PersonReadables
-      PersonAbility.send :include, Pbs::PersonAbility
-      EventAbility.send :include, Pbs::EventAbility
-      EventAbility.send :include, Pbs::Event::Constraints
-      Event::ApplicationAbility.send :include, Pbs::Event::ApplicationAbility
-      Event::ApplicationAbility.send :include, Pbs::Event::Constraints
-      Event::ParticipationAbility.send :include, Pbs::Event::ParticipationAbility
-      Event::ParticipationAbility.send :include, Pbs::Event::Constraints
-      Event::RoleAbility.send :include, Pbs::Event::Constraints
-      QualificationAbility.send :include, Pbs::QualificationAbility
-      TokenAbility.send :include, Pbs::TokenAbility
-      VariousAbility.send :include, Pbs::VariousAbility
+      GroupAbility.include Pbs::GroupAbility
+      PersonReadables.include Pbs::PersonReadables
+      PersonAbility.include Pbs::PersonAbility
+      EventAbility.include Pbs::EventAbility
+      EventAbility.include Pbs::Event::Constraints
+      Event::ApplicationAbility.include Pbs::Event::ApplicationAbility
+      Event::ApplicationAbility.include Pbs::Event::Constraints
+      Event::ParticipationAbility.include Pbs::Event::ParticipationAbility
+      Event::ParticipationAbility.include Pbs::Event::Constraints
+      Event::RoleAbility.include Pbs::Event::Constraints
+      QualificationAbility.include Pbs::QualificationAbility
+      TokenAbility.include Pbs::TokenAbility
+      VariousAbility.include Pbs::VariousAbility
 
       ### decorators
       EventDecorator.icons['Event::Camp'] = :campground
-      EventDecorator.send :include, Pbs::EventDecorator
-      PersonDecorator.send :include, Pbs::PersonDecorator
-      ContactableDecorator.send :include, Pbs::ContactableDecorator
-      Event::ParticipationDecorator.send :include, Pbs::Event::ParticipationDecorator
-      GroupDecorator.send :include, Pbs::GroupDecorator
+      EventDecorator.include Pbs::EventDecorator
+      PersonDecorator.include Pbs::PersonDecorator
+      ContactableDecorator.include Pbs::ContactableDecorator
+      Event::ParticipationDecorator.include Pbs::Event::ParticipationDecorator
+      GroupDecorator.include Pbs::GroupDecorator
       ServiceTokenDecorator.kinds += [:group_health]
 
       ### serializers
-      PersonSerializer.send :include, Pbs::PersonSerializer
-      GroupSerializer.send  :include, Pbs::GroupSerializer
-      EventSerializer.send :include, Pbs::EventSerializer
-      EventParticipationSerializer.send :include, Pbs::EventParticipationSerializer
+      PersonSerializer.include Pbs::PersonSerializer
+      GroupSerializer.include Pbs::GroupSerializer
+      EventSerializer.include Pbs::EventSerializer
+      EventParticipationSerializer.include Pbs::EventParticipationSerializer
 
       ### controllers
       PeopleController.permitted_attrs += [:salutation, :title, :grade_of_school, :entry_date,
@@ -118,36 +99,36 @@ module HitobitoPbs
       QualificationKindsController.permitted_attrs += [:manual]
       ServiceTokensController.permitted_attrs += [:group_health]
 
-      RolesController.send :include, Pbs::RolesController
-      GroupsController.send :include, Pbs::GroupsController
-      PeopleController.send :include, Pbs::PeopleController
-      EventsController.send :include, Pbs::EventsController
-      Event::ApplicationMarketController.send :include, Pbs::Event::ApplicationMarketController
-      Event::ListsController.send :include, Pbs::Event::ListsController
-      Event::ParticipationsController.send :include, Pbs::Event::ParticipationsController
-      Event::QualificationsController.send :include, Pbs::Event::QualificationsController
-      QualificationsController.send :include, Pbs::QualificationsController
+      RolesController.include Pbs::RolesController
+      GroupsController.include Pbs::GroupsController
+      PeopleController.include Pbs::PeopleController
+      EventsController.include Pbs::EventsController
+      Event::ApplicationMarketController.include Pbs::Event::ApplicationMarketController
+      Event::ListsController.include Pbs::Event::ListsController
+      Event::ParticipationsController.include Pbs::Event::ParticipationsController
+      Event::QualificationsController.include Pbs::Event::QualificationsController
+      QualificationsController.include Pbs::QualificationsController
       Person::QueryController.search_columns << :pbs_number
-      SubscriptionsController.send :include, Pbs::SubscriptionsController
+      SubscriptionsController.include Pbs::SubscriptionsController
 
       ### sheets
-      Sheet::Group.send :include, Pbs::Sheet::Group
-      Sheet::Event.send :include, Pbs::Sheet::Event
+      Sheet::Group.include Pbs::Sheet::Group
+      Sheet::Event.include Pbs::Sheet::Event
 
       ### helpers
-      FilterNavigation::Events.send :include, Pbs::FilterNavigation::Events
+      FilterNavigation::Events.include Pbs::FilterNavigation::Events
       admin = NavigationHelper::MAIN.find { |opts| opts[:label] == :admin }
       admin[:active_for] << 'black_lists'
-      ContactAttrs::ControlBuilder.send :include, Pbs::ContactAttrs::ControlBuilder
+      ContactAttrs::ControlBuilder.include Pbs::ContactAttrs::ControlBuilder
 
       ### jobs
-      Event::ParticipationConfirmationJob.send :include, Pbs::Event::ParticipationConfirmationJob
+      Event::ParticipationConfirmationJob.include Pbs::Event::ParticipationConfirmationJob
 
       ### mailers
-      Event::ParticipationMailer.send :include, Pbs::Event::ParticipationMailer
-      Event::RegisterMailer.send :include, Pbs::Event::RegisterMailer
-      Person::AddRequestMailer.send :include, Pbs::Person::AddRequestMailer
-      Person::LoginMailer.send :include, Pbs::Person::LoginMailer
+      Event::ParticipationMailer.include Pbs::Event::ParticipationMailer
+      Event::RegisterMailer.include Pbs::Event::RegisterMailer
+      Person::AddRequestMailer.include Pbs::Person::AddRequestMailer
+      Person::LoginMailer.include Pbs::Person::LoginMailer
 
       # Main navigation
       i = NavigationHelper::MAIN.index { |opts| opts[:label] == :courses }
@@ -173,8 +154,6 @@ module HitobitoPbs
         icon_name: :'info-circle',
         url: :help_path
       )
-
-      # rubocop:enable SingleSpaceBeforeFirstArg
 
       if Delayed::Job.table_exists?
         Event::CampReminderJob.new.schedule

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -46,9 +46,15 @@ module HitobitoPbs
       Event::Qualifier.include Pbs::Event::Qualifier
       Export::Tabular::Events::List.include Pbs::Export::Tabular::Events::List
       Export::Tabular::Events::Row.include Pbs::Export::Tabular::Events::Row
-      Export::Tabular::People::ParticipationsFull.include Pbs::Export::Tabular::People::ParticipationsFull
-      Export::Tabular::People::ParticipationRow.include Pbs::Export::Tabular::People::ParticipationRow
-      Export::Tabular::People::ParticipationNdbjsRow.include Pbs::Export::Tabular::People::ParticipationNdbjsRow
+      Export::Tabular::People::ParticipationsFull.include(
+          Pbs::Export::Tabular::People::ParticipationsFull
+      )
+      Export::Tabular::People::ParticipationRow.include(
+          Pbs::Export::Tabular::People::ParticipationRow
+      )
+      Export::Tabular::People::ParticipationNdbjsRow.include(
+          Pbs::Export::Tabular::People::ParticipationNdbjsRow
+      )
       Export::Tabular::People::PersonRow.include Pbs::Export::Tabular::People::PersonRow
       Export::Tabular::People::PeopleAddress.include Pbs::Export::Tabular::People::PeopleAddress
       Export::Tabular::People::PeopleFull.include Pbs::Export::Tabular::People::PeopleFull

--- a/spec/controllers/supercamps_controller_spec.rb
+++ b/spec/controllers/supercamps_controller_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2019 Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2019-2021 Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -13,7 +13,7 @@ describe SupercampsController do
   let!(:supercamp) { events(:bund_supercamp) }
 
   before do
-    sign_in(people(:al_schekka))
+    sign_in(people(:bulei))
   end
 
   describe 'find available supercamps' do

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -2,7 +2,7 @@
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
-#
+
 # == Schema Information
 #
 # Table name: events

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -2,7 +2,7 @@
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
-#
+
 # == Schema Information
 #
 # Table name: groups

--- a/spec/models/event/course_spec.rb
+++ b/spec/models/event/course_spec.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2014, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -220,6 +220,16 @@ describe Event::Course do
     it 'is not valid when not multiple of 0.5' do
       event.bsv_days = 2.25
       expect(event).not_to be_valid
+    end
+  end
+
+  context 'globally visible' do
+    it 'is true by default' do
+      expect(event).to be_globally_visible
+    end
+
+    it 'is not editable' do
+      expect(event).to_not be_attr_used(:globally_visible)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe Event do
+  subject { Fabricate(:event, groups: [groups(:be)]) }
+
+  it 'is not globally_visible' do
+    is_expected.to_not be_globally_visible
+  end
+end

--- a/spec/regressions/events_controller_camp_spec.rb
+++ b/spec/regressions/events_controller_camp_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -312,9 +312,10 @@ describe EventsController, type: :controller do
         Fabricate(Event::Camp::Role::Leader.name, participation: leader_participation)
       end
 
-      it 'does not show contact details of camp leaders' do
-        get :show, params: { group_id: outside_camp.group_ids.first, id: outside_camp.id }
-        expect(dom).not_to have_selector('a', text: camp_leader.email)
+      it 'does not allow access' do
+        expect do
+          get :show, params: { group_id: outside_camp.group_ids.first, id: outside_camp.id }
+        end.to raise_error(CanCan::AccessDenied)
       end
 
       it 'show contact details if camp is located in own canton' do

--- a/spec/regressions/events_controller_camp_spec.rb
+++ b/spec/regressions/events_controller_camp_spec.rb
@@ -29,7 +29,7 @@ describe EventsController, type: :controller do
       expect(dom.find_link(advisor_mountain.to_s)[:href]).to eq advisor_mountain_link
     end
 
-    it 'only displays person\'s name if no access to show site' do
+    it "only displays person's name if no access to show site" do
       advisor_mountain = Fabricate(Group::Bund::Coach.name.to_sym, group: groups(:bund)).person
       camp.update(advisor_mountain_security_id: advisor_mountain.id)
 


### PR DESCRIPTION
- Anlässe sind nicht mehr global sichtbar
- Kurse dann doch wieder, um das PBS-Kurswesen zu unterstützen
- Einige Rollen bekommen erweiterte Rechte (https://github.com/hitobito/hitobito/issues/1047#issuecomment-791239533)
- Anpassung der EventAbility, um Teilnehmer und Kriseteam zu berechtigen
- Spec-Anpassungen, die vorher auf globaler Sichtbarkeit aufbauten
- Leerzeilen entfernt und neu hinzugefügt

See https://github.com/hitobito/hitobito/issues/1047