### PR TITLE
Adding tags to full household export (Z-47)

### DIFF
--- a/app/domain/pbs/export/tabular/people/households_full.rb
+++ b/app/domain/pbs/export/tabular/people/households_full.rb
@@ -11,7 +11,7 @@ module Pbs::Export::Tabular::People
     def person_attributes
       super +
       [:correspondence_language, :kantonalverband_id,
-       :id, :layer_group_id, :company_name, :company]
+       :id, :layer_group_id, :company_name, :company, :tags]
     end
   end
 end


### PR DESCRIPTION
This adds `tags` to the list of exported person attributes for the (hidden) full household export.

cc @Michael-Schaer 