### PR TITLE
Add help section listing groups & roles that can see me (Z-46, WIP)

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -14,6 +14,8 @@ class HelpController < ApplicationController
     @groups_and_power_users = current_user.groups.distinct.map do |group|
       [group, power_users_for_group_or_above(group)]
     end
+
+    @groups_and_roles_that_see_me = groups_and_roles_that_see_me
   end
 
   private
@@ -37,6 +39,30 @@ class HelpController < ApplicationController
 
   def power_user_ids_for_group(group)
     group.roles.where(type: POWER_USER_ROLE_TYPES).pluck(:person_id)
+  end
+
+  def groups_and_roles_that_see_me
+    groups_and_roles = {}
+    Role::TypeList.new(Group.root_types.first).flatten.each do |role|
+      all_groups.each do |group_id, group_name, group_type|
+        next unless can_see_me?(role, group_id, group_type)
+
+        groups_and_roles[group_id] ||= { name: group_name, roles: [] }
+        groups_and_roles[group_id][:roles] << role.label
+      end
+    end
+    groups_and_roles
+  end
+
+  def all_groups
+    @all_groups ||= Group.order_by_type.pluck(:id, :name, :type)
+  end
+
+  def can_see_me?(role, group_id, group_type)
+    return false if group_type != role.name.deconstantize
+
+    test_person = Ability.new(Person.new(roles: [role.new(group_id: group_id)]))
+    test_person.can?(:show_details, current_user)
   end
 
 end

--- a/app/views/help/index.html.haml
+++ b/app/views/help/index.html.haml
@@ -33,3 +33,14 @@
           %strong= link_to t(".guides.#{help_key}.title"), t(".guides.#{help_key}.url"), target: '_blank'
         %td
           = t(".guides.#{help_key}.description")
+
+%h2= t('.groups_and_roles_that_see_me.title')
+
+%table.table.table-striped
+  %tbody
+    - @groups_and_roles_that_see_me.each do |id, group|
+      %tr
+        %td
+          %strong= link_to group[:name], group_path(id)
+        %td
+          %p= group[:roles].join(", ")

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -328,6 +328,8 @@ de:
           url: http://ticket.scouts.ch
           title: "Ticket: Leitfaden zur Anmeldung von Kursteilnehmenden"
           description: "Das Ticket beschreibt den TN-Anmeldeprozess über die MiData (Mitgliederdatenbank der PBS)"
+      groups_and_roles_that_see_me:
+        title: Rollen, die auf mich Zugriff haben
 
   member_counts:
     created_data_for_year: Die Zahlen von Total %{total} Mitgliedern wurden für %{year} erfolgreich erzeugt.


### PR DESCRIPTION
This proof of concept adds a section to the help page listing all groups & roles that can see the currently logged in user:

![grafik](https://user-images.githubusercontent.com/656013/115419421-9c3be900-a1fa-11eb-9dde-01a9ac6c573f.png)

It adresses a [feature request from PBS](https://trello.com/c/dDLRQ9uf/35-datenschutz-personen-mit-leserechten-auf-die-gruppe-anzeigen?menu=filter&filter=ges) (cc @Michael-Schaer) and an older [request in the forum](https://hitobito.discoursehosting.net/t/wer-hat-auf-mich-zugriff/36):

> hitobito sollte stärker kommunizieren, […] wer denn eigentlich auf meine Daten Zugriff hat. Es geht grundsätzlich ums Bedürfnis, ich will wissen, wer an meine Daten herankommt.

I'm unsure about the following aspects:
1. Whether the determination of «who can see me» is correct, and how to optimize this for multiple entries
2. Whether the placement of the section is good, or whether it should rather be put on a separate page
3. Whether this information is also wanted in hitobito core, and the implementation should therefore be moved 
