### PR TITLE
Show current state of person's event applications (Z-9)

### DIFF
--- a/app/domain/pbs/person/event_queries.rb
+++ b/app/domain/pbs/person/event_queries.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Pbs::Person::EventQueries
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :pending_applications, :participations_and_approvals
+  end
+
+  private
+
+  def pending_applications_with_participations_and_approvals
+    pending_applications_without_participations_and_approvals.includes(:participation, :approvals)
+  end
+end

--- a/app/views/people/_event_aside.html.haml
+++ b/app/views/people/_event_aside.html.haml
@@ -1,0 +1,13 @@
+-#  Copyright (c) 2021 Pfadibewegung Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+= section_table(title, collection) do |item|
+  %td
+    %strong= item.labeled_link
+    - if item.is_a?(Event::Application)
+      %p
+        %i.fa.fa-info-circle
+        = item.current_status_label
+  %td= item.dates_full

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -77,6 +77,11 @@ de:
     coach_title: 8. Coach
 
   event:
+    applications:
+      current_status_rejected: Die Kursteilnahme wurde abgelehnt
+      current_status_approvals_missing: Es sind noch Kursfreigaben ausstehend
+      current_status_inactive: Die Zuteilung ist noch ausstehend
+
     attendances:
       index:
         info: Erfasse hier die Anzahl BSV-Tage für jede Person.

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -62,6 +62,7 @@ module HitobitoPbs
       Export::PeopleExportJob.include Pbs::Export::PeopleExportJob
       Export::EventParticipationsExportJob.include Pbs::Export::EventParticipationsExportJob
       Export::SubscriptionsJob.include Pbs::Export::SubscriptionsJob
+      Person::EventQueries.include Pbs::Person::EventQueries
 
       ### abilities
       Ability.store.register Event::ApprovalAbility


### PR DESCRIPTION
This adds a small info text to the list of a person's pending event applications, indicating their current state. It resolves a [feature request from PBS](https://trello.com/c/tmA52nVw/172-status-kursanmeldung-in-personen%C3%BCbersicht-anzeigen?menu=filter&filter=ges) (cc @Michael-Schaer) and discerns between the following states:
* **Rejected** (if any rejecting approval exists)
* **Missing approvals** (if not all required approvals exist)
* Otherwise **inactive** («Die Zuteilung ist noch ausstehend»)

![z-9-state-of-application](https://user-images.githubusercontent.com/656013/115574974-67936480-a2c2-11eb-9d6d-d06baadc8e2e.png)
