### PR TITLE
Allow Abteilungsleitungen fetching past members

### DIFF
--- a/app/abilities/pbs/group_ability.rb
+++ b/app/abilities/pbs/group_ability.rb
@@ -29,6 +29,10 @@ module Pbs::GroupAbility
         may(:remind_census, :update_member_counts, :delete_member_counts).
         in_same_layer_or_below_if_leader
 
+      permission(:layer_and_below_full).
+          may(:show_past_members).
+          if_abteilungsleitung_in_layer
+
       permission(:approve_applications).may(:index_pending_approvals).if_layer_and_in_same_group
 
       permission(:any).may(:'index_event/camps').all
@@ -46,6 +50,11 @@ module Pbs::GroupAbility
 
   def if_mitarbeiter_gs
     role_type?(Group::Bund::MitarbeiterGs)
+  end
+
+  def if_abteilungsleitung_in_layer
+    in_same_layer_or_below &&
+      role_type?(Group::Abteilung::Abteilungsleitung, Group::Abteilung::AbteilungsleitungStv)
   end
 
   def if_layer_and_in_same_group

--- a/app/decorators/pbs/person_decorator.rb
+++ b/app/decorators/pbs/person_decorator.rb
@@ -24,14 +24,15 @@ module Pbs::PersonDecorator
 
   private
 
-    def layer_group_ids
-      @layer_group_ids ||= current_user.layer_group_ids
-    end
+  def layer_group_ids
+    @layer_group_ids ||= current_user.layer_group_ids
+  end
 
-    def visible_roles
-      @visible_roles ||= roles.select do |role|
-        layer_group_ids.include?(role.group.layer_group_id) || role.visible_from_above
-      end
+  def visible_roles
+    @visible_roles ||= roles_with_deleted.select do |role|
+      (layer_group_ids.include?(role.group.layer_group_id) || role.visible_from_above) &&
+          (!role.deleted? || can?(:show_past_members, role.group))
     end
+  end
 
 end

--- a/app/models/pbs/person.rb
+++ b/app/models/pbs/person.rb
@@ -57,7 +57,8 @@ module Pbs::Person
 
   included do
     Person::PUBLIC_ATTRS << :title << :salutation << :correspondence_language <<
-                            :prefers_digital_correspondence << :kantonalverband_id
+                            :prefers_digital_correspondence << :kantonalverband_id <<
+                            :pbs_number << :entry_date << :leaving_date
 
     alias_method_chain :full_name, :title
 

--- a/app/serializers/pbs/people_serializer.rb
+++ b/app/serializers/pbs/people_serializer.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Pbs::PeopleSerializer
+  extend ActiveSupport::Concern
+
+  included do
+    extension(:public) do |_|
+      details = h.can?(:show_details, item)
+      if details
+        map_properties :gender, :birthday, :pbs_number, :entry_date, :leaving_date,
+                       :primary_group_id
+      end
+    end
+  end
+
+end

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -95,6 +95,7 @@ module HitobitoPbs
 
       ### serializers
       PersonSerializer.include Pbs::PersonSerializer
+      PeopleSerializer.include Pbs::PeopleSerializer
       GroupSerializer.include Pbs::GroupSerializer
       EventSerializer.include Pbs::EventSerializer
       EventParticipationSerializer.include Pbs::EventParticipationSerializer

--- a/spec/controllers/group_health_controller_spec.rb
+++ b/spec/controllers/group_health_controller_spec.rb
@@ -79,13 +79,6 @@ describe GroupHealthController do
           groups(:schekka).update(group_health: true)
         end
 
-        it 'does export the group having opted in' do
-          get :groups, format: :json
-          json = JSON.parse(response.body)
-          groups = json['groups'].select {|g| g['name'] == groups(:schekka).name}
-          expect(groups.size).to eq(1)
-        end
-
         it 'does only export people with roles in a group having opted in' do
           get :people, format: :json
           json = JSON.parse(response.body)


### PR DESCRIPTION
This is an effort to deprecate the group_health endpoints in favor of an alternative architecture based on OAuth API access.

This requires hitobito/hitobito#1378 as a pre-requisite.

See https://github.com/digio-ch/pbs-healthcheck-core/pull/22 for more context.