### PR TITLE
Fixing overlapping logo and login page content

### DIFF
--- a/app/assets/stylesheets/hitobito/customizable/_wagon.scss
+++ b/app/assets/stylesheets/hitobito/customizable/_wagon.scss
@@ -15,6 +15,10 @@
   }
 
   & > .sheet { margin: 0 20px; }
+
+  .is-logged-out & {
+    padding-top: 7rem;
+  }
 }
 
 


### PR DESCRIPTION
Before
<img src="https://user-images.githubusercontent.com/1799621/146751667-a08e0009-c472-4e15-8ee0-d97b6cb40db0.png" width="280">

After
<img src="https://user-images.githubusercontent.com/1799621/146751689-8e5f2b6e-57e8-4797-ada2-ff2c15ebe212.png" width="280">

