### PR TITLE
Feature Pruefung Abo-Mail-Adresse Abteilungskuerzel

### DIFF
--- a/app/controllers/pbs/mailing_lists_controller.rb
+++ b/app/controllers/pbs/mailing_lists_controller.rb
@@ -1,0 +1,13 @@
+module Pbs::MailingListsController
+    extend ActiveSupport::Concern
+
+    included do
+
+      self.permitted_attrs += [:mail_name_without_suffix]
+
+      def assign_attributes
+        super
+        entry.mail_name = [permitted_params[:mail_name_without_suffix], entry.mail_name_suffix].join('.')
+      end
+    end
+end

--- a/app/models/pbs/mailing_list.rb
+++ b/app/models/pbs/mailing_list.rb
@@ -1,0 +1,24 @@
+module Pbs::MailingList
+    extend ActiveSupport::Concern
+
+    included do
+      validate :mail_name_includes_pbs_shortname
+
+      attr_accessor :mail_name_without_suffix
+
+      def mail_name_includes_pbs_shortname
+        unless mail_name.match(/(.+)\.(.+)$/)[2] == mail_name_suffix
+            errors.add(:mail_name, :invalid)
+        end 
+      end
+      
+      def mail_name_without_suffix
+        mail_name.delete_suffix(".#{mail_name_suffix}")
+      end
+
+      def mail_name_suffix
+        group.pbs_shortname.downcase
+      end
+    end
+end
+    

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -1,0 +1,56 @@
+-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+= entry_form(data: { mailing_list_labels: true }, html: { class: 'form-striped'}) do |f|
+  %fieldset
+    = f.labeled_input_fields(:name, :description, :publisher)
+
+    = f.labeled(:mail_name) do
+      .input-append
+        = f.input_field(:mail_name_without_suffix, class: 'span3')
+        %span.add-on= ".#{entry.mail_name_suffix}@#{entry.mail_domain}"
+
+    = f.labeled_input_field(:additional_sender, help: t('.help_additional_sender'), placeholder: "hans.muster@pfadi-beispiel.ch; *@pfadi-muster.ch")
+
+  %fieldset
+    = f.labeled(:preferred_labels) do
+      %div
+        = link_to '#', class: 'chip chip-add' do
+          = ti('associations.add')
+          = icon(:plus)
+        = text_field_tag(:label, nil, style: 'display: none', data: { provide: :typeahead, source: @labels })
+
+      = hidden_field_tag('mailing_list[preferred_labels][]')
+
+      - @preferred_labels.each do |label|
+        %span.chip
+          = label
+          = link_to(icon(:times), '#')
+          = hidden_field_tag('mailing_list[preferred_labels][]', label)
+
+      %span.help-block= t('.help_preferred_labels')
+
+    = f.indented do
+      - if entry.preferred_labels.present?
+        = f.boolean_field(:main_email, caption: t('.caption_main_email_with_preferred_labels').html_safe)
+      - else
+        = f.boolean_field(:main_email, caption: t('.caption_main_email').html_safe)
+
+  %fieldset
+    = f.labeled_input_fields(:mailchimp_list_id, help: t('.help_mailchimp_sync'))
+    = f.labeled_input_fields(:mailchimp_api_key)
+    = f.labeled_boolean_field(:mailchimp_include_additional_emails)
+
+  %fieldset
+    = f.indented do
+      = f.boolean_field(:subscribable, caption: t('.caption_subscribable'))
+    = f.indented do
+      = f.boolean_field(:subscribers_may_post, caption: t('.caption_subscribers_may_post'))
+    = f.indented do
+      = f.boolean_field(:anyone_may_post, caption: t('.caption_anyone_may_post'))
+    = f.indented do
+      = f.boolean_field(:delivery_report, caption: t('.caption_delivery_report'))
+
+  = render_extensions :fields, locals: { f: f }

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -26,6 +26,7 @@ module HitobitoPbs
       Role.include Pbs::Role
       Qualification.include Pbs::Qualification
       Event.include Pbs::Event
+      MailingList.include Pbs::MailingList
       Event::Kind.include Pbs::Event::Kind
       Event::Course.include Pbs::Event::Course
       Event::Participation.include Pbs::Event::Participation
@@ -110,6 +111,7 @@ module HitobitoPbs
 
       RolesController.include Pbs::RolesController
       GroupsController.include Pbs::GroupsController
+      MailingListsController.include Pbs::MailingListsController
       Person::HouseholdsController.include Pbs::Person::HouseholdsController
       PeopleController.include Pbs::PeopleController
       EventsController.include Pbs::EventsController


### PR DESCRIPTION
Mögliche Lösung für die Prüfung der Abo-Mail-Adresse mit angehängtem Abteilungskürzel.