### PR TITLE
Textanpassung Erwartete Anzahl Teilnehmende

### DIFF
--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -1059,7 +1059,7 @@ de:
         local_scout_contact_present: Lokaler Pfadi Kontakt
         local_scout_contact: Lokale Pfadi Kontaktinfos
         updated_at: Zuletzt aktualisiert
-        any_expected_participant_attr: Erwartete Teilnehmer*innen
+        any_expected_participant_attr: Erwartete Anzahl Teilnehmende
         abteilungsleitung_id: Abteilungsleiter*in
         abteilungsleitung: Abteilungsleiter*in
         leader: Lagerleiter*in


### PR DESCRIPTION
Bei der Warnung für die Lagermeldung sollten alle Felder gleich heissen wie im Formular
Screenshot der Warnung: https://i.ibb.co/Zc6bt2b/warning.png