### PR TITLE
Let role Bund:AusbildungAssistenz manage attendances...

### DIFF
--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -52,8 +52,8 @@ module Pbs::EventAbility
         may(:index_approvals).
         for_advised_or_participations_full_events
 
-      permission(:any).may(:manage_attendances).if_assistanz_ausbildung
-      permission(:any).may(:qualifications_read).if_assistanz_ausbildung
+      permission(:any).may(:manage_attendances).if_assistenz_ausbildung
+      permission(:any).may(:qualifications_read).if_assistenz_ausbildung
 
       permission(:layer_full).may(:manage_attendances, :index_approvals).in_same_layer
 
@@ -99,7 +99,7 @@ module Pbs::EventAbility
                Group::Bund::MitarbeiterGs)
   end
 
-  def if_assistanz_ausbildung
+  def if_assistenz_ausbildung
     role_type?(Group::Bund::AssistenzAusbildung)
   end
 

--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -49,6 +49,7 @@ module Pbs::EventAbility
       permission(:any).may(:manage_attendances).for_leaded_events_or_assistenz_ausbildung
       permission(:any).may(:update).for_advised_courses
       permission(:any).may(:qualifications_read).for_advised_courses_or_assistenz_ausbildung
+      permission(:any).may(:qualify).if_assistenz_ausbildung
       permission(:any).
         may(:index_approvals).
         for_advised_or_participations_full_events

--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -52,6 +52,9 @@ module Pbs::EventAbility
         may(:index_approvals).
         for_advised_or_participations_full_events
 
+      permission(:any).may(:manage_attendances).if_assistanz_ausbildung
+      permission(:any).may(:qualifications_read).if_assistanz_ausbildung
+
       permission(:layer_full).may(:manage_attendances, :index_approvals).in_same_layer
 
       permission(:layer_and_below_full).may(:manage_attendances).in_same_layer
@@ -94,6 +97,10 @@ module Pbs::EventAbility
   def if_education_responsible
     role_type?(Group::Bund::AssistenzAusbildung,
                Group::Bund::MitarbeiterGs)
+  end
+
+  def if_assistanz_ausbildung
+    role_type?(Group::Bund::AssistenzAusbildung)
   end
 
   def if_mitarbeiter_gs

--- a/app/abilities/pbs/event_ability.rb
+++ b/app/abilities/pbs/event_ability.rb
@@ -46,14 +46,12 @@ module Pbs::EventAbility
     end
 
     on(Event::Course) do
-      permission(:any).may(:manage_attendances).for_leaded_events
-      permission(:any).may(:update, :qualifications_read).for_advised_courses
+      permission(:any).may(:manage_attendances).for_leaded_events_or_assistenz_ausbildung
+      permission(:any).may(:update).for_advised_courses
+      permission(:any).may(:qualifications_read).for_advised_courses_or_assistenz_ausbildung
       permission(:any).
         may(:index_approvals).
         for_advised_or_participations_full_events
-
-      permission(:any).may(:manage_attendances).if_assistenz_ausbildung
-      permission(:any).may(:qualifications_read).if_assistenz_ausbildung
 
       permission(:layer_full).may(:manage_attendances, :index_approvals).in_same_layer
 
@@ -88,6 +86,14 @@ module Pbs::EventAbility
     if_globally_visible_or_participating_without_pbs ||
       participating? ||
       if_part_of_krisenteam
+  end
+
+  def for_advised_courses_or_assistenz_ausbildung
+    for_advised_courses || if_assistenz_ausbildung
+  end
+
+  def for_leaded_events_or_assistenz_ausbildung
+    for_leaded_events || if_assistenz_ausbildung
   end
 
   def for_advised_courses

--- a/spec/abilities/event_ability_spec.rb
+++ b/spec/abilities/event_ability_spec.rb
@@ -290,6 +290,30 @@ describe EventAbility do
     end
   end
 
+  context :manage_attendances do
+
+    context 'assistenz ausbildung' do
+      let(:role) { Fabricate(Group::Bund::AssistenzAusbildung.name.to_sym, group: groups(:bund)) }
+
+      context 'in kanton' do
+        it 'may manage attendances and qualifications' do
+          is_expected.to be_able_to(:manage_attendances, events(:top_course))
+          is_expected.to be_able_to(:qualifications_read, events(:top_course))
+        end
+      end
+    end
+
+    context 'mitarbeiter gs' do
+      let(:role) { Fabricate(Group::Bund::MitarbeiterGs.name.to_sym, group: groups(:bund)) }
+
+      context 'in kanton' do
+        it 'may manage attendances and qualifications' do
+          is_expected.not_to be_able_to(:manage_attendances, events(:top_course))
+          is_expected.not_to be_able_to(:qualifications_read, events(:top_course))
+        end
+      end
+    end
+  end
 
   context :modify_superior do
 

--- a/spec/support/custom_content_placeholders.rb
+++ b/spec/support/custom_content_placeholders.rb
@@ -43,4 +43,3 @@ CustomContent.seed(:key,
     placeholders_required: 'person-name, request-body',
     placeholders_optional: 'recipient-name-with-salutation, recipient-name, rejecter-name, rejecter-roles' },
 )
-


### PR DESCRIPTION
Die Person mit der Rolle AusbildungAssistenz muss bisher jeweils die richtige Person finden, um Anwesenheiten bei Kursen zu überprüfen und nicht abgeschlossene Formulare zu schliessen. Dies ist relevant für Kursabschlüsse und BSV-Exporte. 

Mit dieser Änderung kann die Person nun selber Anpassungen an den Anwesenheiten und Qualifikationen für alle Kurse vornehmen.