### PR TITLE
Fix creating event roles for people who already have one

### DIFF
--- a/app/controllers/pbs/event/roles_controller.rb
+++ b/app/controllers/pbs/event/roles_controller.rb
@@ -1,14 +1,16 @@
 # encoding: utf-8
 
-#  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2023, Pfadibewegung Schweiz. This file is part of
 #  hitobito_pbs and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
 
 module Pbs::Event::RolesController
-  extend ActiveSupport::Concern
-
-  included do
-    self.permitted_attrs += [{ participation_attributes: :j_s_data_sharing_accepted }]
+  def build_entry
+    super.tap do |role|
+      attrs = params[:event_role] || {}
+      accepted = attrs.dig(:participation_attributes, :j_s_data_sharing_accepted)
+      role.participation.j_s_data_sharing_accepted = true?(accepted)
+    end
   end
 end

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -127,7 +127,7 @@ module HitobitoPbs
       Event::ListsController.include Pbs::Event::ListsController
       Event::ParticipationsController.include Pbs::Event::ParticipationsController
       Event::QualificationsController.include Pbs::Event::QualificationsController
-      Event::RolesController.include Pbs::Event::RolesController
+      Event::RolesController.prepend Pbs::Event::RolesController
       QualificationsController.include Pbs::QualificationsController
       Person::QueryController.search_columns << :pbs_number
       SubscriptionsController.include Pbs::SubscriptionsController

--- a/spec/controllers/event/roles_controller_spec.rb
+++ b/spec/controllers/event/roles_controller_spec.rb
@@ -28,7 +28,10 @@ describe Event::RolesController do
                  event_id: event.id,
                  event_role: {
                    type: Event::Role::Cook.sti_name,
-                   person_id: people(:al_berchtold).id
+                   person_id: people(:al_berchtold).id,
+                   participation_attributes: {
+                     j_s_data_sharing_accepted: [ '0', '1' ]
+                   }
                  }
                }
         end.to change { Event::Participation.count }.by(1)
@@ -50,7 +53,10 @@ describe Event::RolesController do
                  event_id: event.id,
                  event_role: {
                    type: Event::Role::Cook.sti_name,
-                   person_id: people(:al_berchtold).id
+                   person_id: people(:al_berchtold).id,
+                   participation_attributes: {
+                     j_s_data_sharing_accepted: [ '0', '1' ]
+                   }
                  }
                }
         end.to change { Event::Participation.count }.by(1)
@@ -73,7 +79,10 @@ describe Event::RolesController do
                  event_id: event.id,
                  event_role: {
                    type: Event::Camp::Role::LeaderSnowSecurity.sti_name,
-                   person_id: people(:al_berchtold).id
+                   person_id: people(:al_berchtold).id,
+                   participation_attributes: {
+                     j_s_data_sharing_accepted: [ '0', '1' ]
+                   }
                  }
                }
         end.to change { Event::Participation.count }.by(1)
@@ -96,7 +105,10 @@ describe Event::RolesController do
                  event_id: event.id,
                  event_role: {
                    type: Event::Camp::Role::Helper.sti_name,
-                   person_id: people(:al_berchtold).id
+                   person_id: people(:al_berchtold).id,
+                   participation_attributes: {
+                     j_s_data_sharing_accepted: [ '0', '1' ]
+                   }
                  }
                }
         end.to change { Event::Participation.count }.by(1)
@@ -114,10 +126,35 @@ describe Event::RolesController do
                  event_id: event.id,
                  event_role: {
                    type: Event::Camp::Role::Participant.sti_name,
-                   person_id: people(:al_berchtold).id
+                   person_id: people(:al_berchtold).id,
+                   participation_attributes: {
+                     j_s_data_sharing_accepted: [ '0', '1' ]
+                   }
                  }
                }
         end.to change { Event::Participation.count }.by(1)
+
+        role = assigns(:role)
+        expect(role).to be_persisted
+        expect(role.participation.state).to eq 'assigned'
+      end
+
+      it 'creates assistant leader role for existing participant' do
+        person = event.participations.first.person
+        expect do
+          post :create,
+               params: {
+                 group_id: group.id,
+                 event_id: event.id,
+                 event_role: {
+                   type: Event::Camp::Role::AssistantLeader.sti_name,
+                   person_id: person.id,
+                   participation_attributes: {
+                     j_s_data_sharing_accepted: [ '0', '1' ]
+                   }
+                 }
+               }
+        end.to change { Event::Role.count }.by(1)
 
         role = assigns(:role)
         expect(role).to be_persisted


### PR DESCRIPTION
Fixes an oversight from https://github.com/hitobito/hitobito/issues/1956
Fixes https://help.puzzle.ch/#ticket/zoom/5860

The attributes of the event participations and event roles have been assigned in a nonstandard way since 2012. Unfortunately, this means we cannot just extend the available fields in the normal way (by adding to the permitted_attrs). Instead, we have to extend the build_entry method so that it sets the fields.
Extending the permitted_attrs works when only adding completely new people to the event. But when adding another role for a person who already had a participation in the event, the assign_attributes call would completely overwrite the role's participation which has previously been carefully crafted in the build_entry method.