### PR TITLE
Improve camp and course participant exports

### DIFF
--- a/app/helpers/pbs/dropdown/people_export.rb
+++ b/app/helpers/pbs/dropdown/people_export.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Pbs
+  module Dropdown
+    module PeopleExport
+      extend ActiveSupport::Concern
+
+      def is_course?(event)
+        event.is_a?(::Event::Course)
+      end
+
+      def is_camp?(event)
+        event.is_a?(::Event::Camp)
+      end
+
+    end
+  end
+end

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -408,3 +408,8 @@ de:
 
   global:
     title_event/camp: Lager
+
+  dropdown/people_export:
+    nds_course: NDS-Kurs (nur TN)
+    nds_camp: NDS-Lager (nur TN)
+    slrg: SLRG-Kurs (nur TN)

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -65,7 +65,7 @@ module HitobitoPbs
       Export::Tabular::People::PeopleFull.include Pbs::Export::Tabular::People::PeopleFull
       Export::Tabular::Events::BsvRow.include Pbs::Export::Tabular::Events::BsvRow
       Export::PeopleExportJob.include Pbs::Export::PeopleExportJob
-      Export::EventParticipationsExportJob.include Pbs::Export::EventParticipationsExportJob
+      Export::EventParticipationsExportJob.prepend Pbs::Export::EventParticipationsExportJob
       Export::SubscriptionsJob.include Pbs::Export::SubscriptionsJob
 
       Person::AddRequest::Approver::Event.prepend(

--- a/lib/hitobito_pbs/wagon.rb
+++ b/lib/hitobito_pbs/wagon.rb
@@ -142,6 +142,7 @@ module HitobitoPbs
       admin = NavigationHelper::MAIN.find { |opts| opts[:label] == :admin }
       admin[:active_for] << 'black_lists'
       ContactAttrs::ControlBuilder.include Pbs::ContactAttrs::ControlBuilder
+      Dropdown::PeopleExport.include Pbs::Dropdown::PeopleExport
 
       ### jobs
       Event::ParticipationConfirmationJob.include Pbs::Event::ParticipationConfirmationJob


### PR DESCRIPTION
Merge together with hitobito/hitobito_youth#26

- Versteckt die NDS-Kurs bzw. NDS-Lager Export-Optionen in Anlässen wo sie klar nicht gültig sind
- Exportiert immer nur die Teilnehmenden bei NDS-Kursen, NDS-Lagern und SLRG-Kursen, egal welche Filter gerade eingestellt sind. Zur Info wurde auch noch die Übersetzung der Dropdown-Optionen angepasst.