### PR TITLE
Daily job to delete possible unneeded sensitive information from event applications

### DIFF
--- a/app/jobs/cleanup_course_approvals_job.rb
+++ b/app/jobs/cleanup_course_approvals_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2023, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class CleanupCourseApprovalsJob < RecurringJob
+
+  run_every 1.day
+
+  def perform
+    Event::Approval.
+    joins(participation: { event: :event_dates }).
+    where('event_dates.id = :last_finish',
+      last_finish: Event::Date.select('id').
+      where('event_id = ?', :event_date).
+      order(finish_at: :desc).limit(1)).
+    where(events: { state: 'closed' }).
+    where('event_dates.finish_at < ?', 3.months.ago).
+    update_all(comment: nil, current_occupation: nil,
+        current_level: nil, occupation_assessment: nil,
+        strong_points: nil, weak_points: nil)
+
+  end
+end

--- a/spec/jobs/cleanup_course_approvals_job_spec.rb
+++ b/spec/jobs/cleanup_course_approvals_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe CleanupCourseApprovalsJob do
+  include ActiveJob::TestHelper
+
+  let(:job) { CleanupCourseApprovalsJob.new }
+  
+  context 'when configured' do
+    it 'runs cleanup job' do
+      job.perform
+    end
+  end
+end


### PR DESCRIPTION
Die Übersetzung von SQL in Active Record ist noch nicht ganz gelungen. 


SQL-Code:

```

UPDATE event_approvals ea
JOIN event_participations ep ON ep.application_id = ea.application_id
JOIN events e ON ep.event_id = [e.id](http://e.id/)
JOIN event_dates ed ON [e.id](http://e.id/) = ed.event_id
SET ea.comment=NULL, ea.current_occupation=NULL,
ea.current_level=NULL, ea.occupation_assessment=NULL,
ea.strong_points=NULL, ea.weak_points=NULL
WHERE ed.id = (SELECT id FROM event_dates WHERE event_id=ed.event_id ORDER BY finish_at DESC LIMIT 1)
AND e.state = 'closed'
AND ed.finish_at < DATE_SUB(CURDATE(), INTERVAL 90 DAY);
```

Fixes https://github.com/hitobito/hitobito/issues/1060