### PR TITLE
Remove link to 1x1 MiData for coaches from the help page

### DIFF
--- a/app/views/help/index.html.haml
+++ b/app/views/help/index.html.haml
@@ -27,7 +27,7 @@
 
 %table.table.table-striped
   %tbody
-    - %w(hering coaches ticket anker pilot).each do |help_key|
+    - %w(hering ticket anker pilot).each do |help_key|
       %tr
         %td
           %strong= link_to t(".guides.#{help_key}.title"), t(".guides.#{help_key}.url"), target: '_blank'

--- a/config/locales/views.pbs.de.yml
+++ b/config/locales/views.pbs.de.yml
@@ -319,10 +319,6 @@ de:
           url: http://hering.scouts.ch
           title: "Hering: Leitfaden zur Administration von Pfadilagern"
           description: "Der Hering bietet dir sämtliche Informationen zur Administration von Pfadilagern. Er führt dich Schritt für Schritt durch alle wichtigen Dokumente. Mit diesem Leitfaden wirst du keinen wichtigen Punkt vergessen."
-        coaches:
-          url: http://coaches.scouts.ch
-          title: 1x1 MiData für Coaches
-          description: "Das «1x1 MiData für Coaches» erläutert die für Coaches wichtigsten Funktionen der PBS-Mitgliederdatenbank (Mi-Data). Es dient sowohl als Factsheet, als auch als Vorbereitung für das MF-Coach und den Coachkurs."
         anker:
           url: http://anker.scouts.ch
           title: "Anker: Leitfaden zur PBS Kursadministration"

--- a/config/locales/views.pbs.fr.yml
+++ b/config/locales/views.pbs.fr.yml
@@ -293,10 +293,6 @@ fr:
           url: http://heringfr.scouts.ch
           title: "Sardine: Guide des démarches administratives pour les camps scouts"
           description: "La sardine te donne toutes les informations pour l'administration de camps scouts. Elle te mène pas à pas à travers tous les documents importants. Avec ce guide, tu n'oublieras aucun point important."
-        coaches:
-          url: http://coachesfr.scouts.ch
-          title: 1x1 MiData pour coachs
-          description: "Le « 1x1 MiData pour coachs » explique les fonctions les plus importantes pour les coachs dans l’utilisation de la base de données des membres du MSdS (MiData). Il sert autant de résumé que de préparation pour le MP-Coach et le cours de coachs."
         anker:
           url: http://ankerfr.scouts.ch
           title: "L’ancre: Fil conducteur pour l’administration des cours MSdS"

--- a/config/locales/views.pbs.it.yml
+++ b/config/locales/views.pbs.it.yml
@@ -293,10 +293,6 @@ it:
           url: http://heringit.scouts.ch
           title: "Sardina: linee guida per l'amministrazione di campi scout"
           description: "Sardina include tutte le informazioni per l'amministrazione di campi scout. Ti porta passo a passo a tutti i documenti più importanti. Con queste linee guida non dimenticherai nessun punto importante."
-        coaches:
-          url: http://coachesfr.scouts.ch
-          title: 1x1 MiData per coaches
-          description: "\"1x1 MiData per coaches\" spiega per i coaches le funzioni più importanti per la banca data dei membri del MSS (MiData). Vale sia quale Factsheet che come preparazione per il coach MF e per il corso coach."
         anker:
           url: http://ankerit.scouts.ch
           title: "Ancora: guida sull'amministrazione dei corsi MSS"


### PR DESCRIPTION
"1x1 MiData for coaches" was archived. This pr removes the link to the document