### PR TITLE
Neue Gruppe für Elternaccounts

### DIFF
--- a/app/controllers/group_health_controller.rb
+++ b/app/controllers/group_health_controller.rb
@@ -40,7 +40,7 @@ class GroupHealthController < ApplicationController
                 'AND canton.type = "Group::Kantonalverband"'.freeze
 
   # exclude Group::InternesGremium groups
-  INTERNES_GREMIUM_GROUP_TYPES = [Group::InternesGremium, Group::InternesAbteilungsGremium]
+  INTERNES_GREMIUM_GROUP_TYPES = [Group::InternesGremium, Group::InternesAbteilungsGremium, Group::ErziehungsberechtigtenGremium]
   EXCLUDE_INTERNES_GREMIUM = "#{Group.quoted_table_name}.type NOT IN" \
     "(#{INTERNES_GREMIUM_GROUP_TYPES.map { |type| "'#{type.to_s}'" }.join(', ')})".freeze
 

--- a/app/controllers/group_health_controller.rb
+++ b/app/controllers/group_health_controller.rb
@@ -40,7 +40,8 @@ class GroupHealthController < ApplicationController
                 'AND canton.type = "Group::Kantonalverband"'.freeze
 
   # exclude Group::InternesGremium groups
-  INTERNES_GREMIUM_GROUP_TYPES = [Group::InternesGremium, Group::InternesAbteilungsGremium, Group::ErziehungsberechtigtenGremium]
+  INTERNES_GREMIUM_GROUP_TYPES = [Group::InternesGremium, Group::InternesAbteilungsGremium, 
+                                  Group::ErziehungsberechtigtenGremium]
   EXCLUDE_INTERNES_GREMIUM = "#{Group.quoted_table_name}.type NOT IN" \
     "(#{INTERNES_GREMIUM_GROUP_TYPES.map { |type| "'#{type.to_s}'" }.join(', ')})".freeze
 

--- a/app/models/group/abteilung.rb
+++ b/app/models/group/abteilung.rb
@@ -67,7 +67,8 @@ class Group::Abteilung < Group
            Group::Pta,
            Group::Elternrat,
            Group::AbteilungsGremium,
-           Group::InternesAbteilungsGremium
+           Group::InternesAbteilungsGremium,
+           Group::ErziehungsberechtigtenGremium
 
   has_many :member_counts # rubocop:disable Rails/HasManyOrHasOneDependent since groups are only soft-deleted
   has_many :geolocations, as: :geolocatable, dependent: :destroy

--- a/app/models/group/erziehungsberechtigten_gremium.rb
+++ b/app/models/group/erziehungsberechtigten_gremium.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+# == Schema Information
+#
+# Table name: groups
+#
+#  id                          :integer          not null, primary key
+#  parent_id                   :integer
+#  lft                         :integer
+#  rgt                         :integer
+#  name                        :string(255)      not null
+#  short_name                  :string(31)
+#  type                        :string(255)      not null
+#  email                       :string(255)
+#  address                     :string(1024)
+#  zip_code                    :integer
+#  town                        :string(255)
+#  country                     :string(255)
+#  contact_id                  :integer
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  deleted_at                  :datetime
+#  layer_group_id              :integer
+#  creator_id                  :integer
+#  updater_id                  :integer
+#  deleter_id                  :integer
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  pta                         :boolean          default(FALSE), not null
+#  vkp                         :boolean          default(FALSE), not null
+#  pbs_material_insurance      :boolean          default(FALSE), not null
+#  website                     :string(255)
+#  pbs_shortname               :string(15)
+#  bank_account                :string(255)
+#  description                 :text
+#  application_approver_role   :string
+#  gender                      :string(1)
+#  try_out_day_at              :date
+#
+
+class Group::ErziehungsberechtigtenGremium < Group::InternesGremium
+
+  children Group::ErziehungsberechtigtenGremium
+
+  class Mitglied < Group::InternesGremium::Mitglied
+    self.permissions = []
+    self.basic_permissions_only = true
+  end
+
+  class Selbstregistriert < Group::InternesGremium::Mitglied
+    self.permissions = []
+    self.basic_permissions_only = true
+  end
+
+  roles Mitglied, Selbstregistriert
+  self.default_role = Mitglied
+
+end

--- a/config/locales/models.pbs.de.yml
+++ b/config/locales/models.pbs.de.yml
@@ -44,6 +44,10 @@ de:
         one: Internes Gremium
         other: Interne Gremien
         long: Internes Abteilungsgremium
+      group/erziehungsberechtigten_gremium:
+        one: Erziehungsberechtigte
+        other: Erziehungsberechtigte
+        long: Erziehungsberechtigte
       group/internes_gremium:
         one: Internes Gremium
         other: Interne Gremien
@@ -921,6 +925,15 @@ de:
       group/internes_gremium/mitglied:
         one: Mitglied
         other: Mitglieder
+        description:
+
+      group/erziehungsberechtigten_gremium/mitglied:
+        one: Mitglied
+        other: Mitglieder
+        description:
+      group/erziehungsberechtigten_gremium/selbstregistriert:
+        one: Selbstregistrierte*r
+        other: Selbstregistrierte
         description:
 
       group/gremium/leitung:

--- a/config/locales/models.pbs.fr.yml
+++ b/config/locales/models.pbs.fr.yml
@@ -42,9 +42,13 @@ fr:
         other: Comités internes
         long: Comité de groupe interne
       group/internes_gremium:
-        one: comité interne
+        one: Comité interne
         many: Comités internes
         other: Comités internes
+      group/erziehungsberechtigten_gremium:
+        one: Responsables légaux
+        many: Responsables légaux
+        other: Responsables légaux
       group/internes_kantonales_gremium:
         one: Comité interne
         other: Comités internes
@@ -913,6 +917,14 @@ fr:
         one: membre
         many: membres
         other: membres
+      group/erziehungsberechtigten_gremium/mitglied:
+        one: membre
+        many: membres
+        other: membres
+      group/erziehungsberechtigten_gremium/selbstregistriert:
+        one: auto-enregistré·e
+        many: auto-enregistré·e·s
+        other: auto-enregistré·e·s
       group/gremium/leitung:
         one: Responsable
         many: Responsables

--- a/config/locales/models.pbs.it.yml
+++ b/config/locales/models.pbs.it.yml
@@ -45,6 +45,10 @@ it:
         one: Comitato interno
         many: Gremi interni
         other: Gremi interni
+      group/erziehungsberechtigten_gremium:
+        one: Tutore legale
+        many: Tutore legale
+        other: Tutore legale
       group/internes_kantonales_gremium:
         one: Gremio interna
         other: Commissioni interne
@@ -916,7 +920,7 @@ it:
         many: Membri
         other: Membri
       group/elternrat/selbstregistriert:
-        one: Autoregistrazione
+        one: Autoregistrazionxe
         many: Autoregistrazione
         other: Autoregistrazione
       group/internes_gremium/leitung:
@@ -927,6 +931,14 @@ it:
         one: Membro
         many: Membri
         other: Membri
+      group/erziehungsberechtigten_gremium/mitglied:
+        one: Membro
+        many: Membri
+        other: Membri
+      group/erziehungsberechtigten_gremium/selbstregistriert:
+        one: Autoregistrazione
+        many: Autoregistrazione
+        other: Autoregistrazione
       group/gremium/leitung:
         one: Formatore
         many: Responsabile

--- a/config/locales/models.pbs.it.yml
+++ b/config/locales/models.pbs.it.yml
@@ -920,7 +920,7 @@ it:
         many: Membri
         other: Membri
       group/elternrat/selbstregistriert:
-        one: Autoregistrazionxe
+        one: Autoregistrazione
         many: Autoregistrazione
         other: Autoregistrazione
       group/internes_gremium/leitung:

--- a/db/seeds/development/0_groups.rb
+++ b/db/seeds/development/0_groups.rb
@@ -188,4 +188,9 @@ Group::AbteilungsGremium.seed(:name, :parent_id,
    parent_id: abteilungen[2].id},
 )
 
+Group::ErziehungsberechtigtenGremium.seed(:name, :parent_id,
+  {name: 'Erziehungsberechtigte',
+   parent_id: abteilungen[5].id},
+)
+
 Group.rebuild!

--- a/spec/domain/role/type_list_spec.rb
+++ b/spec/domain/role/type_list_spec.rb
@@ -20,7 +20,8 @@ describe Role::TypeList do
       ['Kantonalverband', ['Kantonalverband', 'Gremium', 'Internes Gremium', 'Kommission']],
       ['Region', ['Region', 'Rover', 'Gremium', 'Internes Gremium', 'Kommission']],
       ['Abteilung', ['Abteilung', 'Biber', 'Wölfe', 'Pfadi', 'Pio',
-                     'Rover', 'PTA', 'Elternrat', 'Gremium', 'Internes Gremium']],
+                     'Rover', 'PTA', 'Elternrat', 'Gremium', 'Internes Gremium', 
+                     'Erziehungsberechtigte']],
     ])
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -73,6 +73,7 @@ describe Group do
          Group::Elternrat,
          Group::AbteilungsGremium,
          Group::InternesAbteilungsGremium,
+         Group::ErziehungsberechtigtenGremium, 
          Group::KantonalesGremium,
          Group::InternesKantonalesGremium,
          Group::KantonaleKommission,


### PR DESCRIPTION
Eine neue Gruppe für die Elternaccounts wie ein interes Gremium erstellt. Rollen:
- Mitglied
- Selbstregistrierte*r
Beide Rollen mit basic_permission_only und ausgenommen vom HealthCheck Export.