### PR TITLE
Fix group_health API bugs

### DIFF
--- a/app/controllers/group_health_controller.rb
+++ b/app/controllers/group_health_controller.rb
@@ -78,6 +78,7 @@ class GroupHealthController < ApplicationController
   def groups
     respond(Group.from("((#{bund}) UNION (#{cantons}) UNION (#{abt_and_below})) " \
                        "AS #{Group.quoted_table_name}")
+                .select(GROUPS_FIELDS)
                 .where(EXCLUDE_INTERNES_GREMIUM)
                 .order(:lft)
                 .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
@@ -131,6 +132,7 @@ class GroupHealthController < ApplicationController
 
   def qualification_kinds
     respond(QualificationKind.includes(:translations)
+                .select(QUALIFICATION_KINDS_FIELDS)
                 .as_json(only: QUALIFICATION_KINDS_FIELDS,
                   include: {translations: {only: TRANSLATIONS_FIELDS}})
                 .map { |item| set_translations(item, "label") })
@@ -138,6 +140,7 @@ class GroupHealthController < ApplicationController
 
   def event_kinds
     respond(Event::Kind.includes(:translations, :event_kind_qualification_kinds)
+                .select(EVENT_KINDS_FIELDS)
                 .as_json(only: EVENT_KINDS_FIELDS,
                   include: {translations: {only: TRANSLATIONS_FIELDS},
                             event_kind_qualification_kinds: {only: EKQK_FIELDS}})

--- a/app/controllers/group_health_controller.rb
+++ b/app/controllers/group_health_controller.rb
@@ -58,6 +58,7 @@ class GroupHealthController < ApplicationController
       respond(Person.joins(roles: :group)
                   .joins(GROUP_HEALTH_JOIN).distinct
                   .where(EXCLUDE_INTERNES_GREMIUM)
+                  .order(:id)
                   .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                   .as_json(only: PERSON_FIELDS)
                   .map { |item| set_name(item) })
@@ -69,6 +70,7 @@ class GroupHealthController < ApplicationController
                 .joins(:group)
                 .where(EXCLUDE_INTERNES_GREMIUM)
                 .joins(GROUP_HEALTH_JOIN).distinct
+                .order(:id)
                 .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                 .as_json(only: ROLES_FIELDS))
   end
@@ -87,6 +89,7 @@ class GroupHealthController < ApplicationController
                 .joins(GROUP_HEALTH_JOIN).distinct
                 .where(EXCLUDE_INTERNES_GREMIUM)
                 .includes(:dates, :groups)
+                .order(:id)
                 .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                 .as_json(only: COURSES_FIELDS,
                   include: {dates: {only: EVENT_DATES_FIELDS},
@@ -98,6 +101,7 @@ class GroupHealthController < ApplicationController
                 .joins(GROUP_HEALTH_JOIN).distinct
                 .where(EXCLUDE_INTERNES_GREMIUM)
                 .includes(:dates, :groups)
+                .order(:id)
                 .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                 .as_json(only: CAMPS_FIELDS,
                   include: {dates: {only: EVENT_DATES_FIELDS},
@@ -109,8 +113,9 @@ class GroupHealthController < ApplicationController
     respond(Event::Participation.joins(person: [{roles: :group}])
                 .joins(GROUP_HEALTH_JOIN).distinct
                 .where(EXCLUDE_INTERNES_GREMIUM)
-                .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                 .includes(:roles)
+                .order(:id)
+                .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                 .as_json(only: PARTICIPATIONS_FIELDS,
                   include: {roles: {only: PARTICIPATIONS_ROLES_FIELDS}}))
   end
@@ -119,6 +124,7 @@ class GroupHealthController < ApplicationController
     respond(Qualification.joins(person: [{roles: :group}])
                 .joins(GROUP_HEALTH_JOIN).distinct
                 .where(EXCLUDE_INTERNES_GREMIUM)
+                .order(:id)
                 .page(params[:page]).per(params[:size] || DEFAULT_PAGE_SIZE)
                 .as_json)
   end

--- a/spec/controllers/group_health_controller_spec.rb
+++ b/spec/controllers/group_health_controller_spec.rb
@@ -243,7 +243,10 @@ describe GroupHealthController do
           it "does only export people with roles in a group having opted in" do
             get :people, format: :json
             json = JSON.parse(response.body)
-            expect(json["people"].size).to eq(2)
+            people = json["people"]
+            expect(people.size).to eq(2)
+            person = people.first
+            expect(person.keys).to match_array(%w[id pbs_number town zip_code country gender birthday entry_date leaving_date primary_group_id name address])
           end
 
           it "does only export camps with participants having roles in a group having opted in" do

--- a/spec/controllers/group_health_controller_spec.rb
+++ b/spec/controllers/group_health_controller_spec.rb
@@ -93,6 +93,7 @@ describe GroupHealthController do
           json = JSON.parse(response.body)
           group = json["groups"].first
           expect(group["name"]).to eq(groups(:bund).name)
+          expect(group["canton_id"]).to be_nil
         end
       end
 
@@ -224,6 +225,9 @@ describe GroupHealthController do
             json = JSON.parse(response.body)
             groups = json["groups"].select { |g| g["name"] == groups(:schekka).name }
             expect(groups.size).to eq(1)
+            group = groups.first
+            expect(group.keys).to match_array(%w[id parent_id type name created_at deleted_at canton_id canton_name])
+            expect(group["canton_id"]).to eq(groups(:be).id)
           end
 
           it "does not export internes Gremium" do
@@ -304,6 +308,9 @@ describe GroupHealthController do
             json = JSON.parse(response.body)
             groups = json["groups"].select { |g| g["name"] == groups(:be).name }
             expect(groups.size).to eq(1)
+            group = groups.first
+            expect(group.keys).to match_array(%w[id parent_id type name created_at deleted_at canton_id canton_name])
+            expect(group["canton_id"]).to eq(groups(:be).id)
           end
 
           it "does not export internes Gremium" do
@@ -383,6 +390,9 @@ describe GroupHealthController do
             json = JSON.parse(response.body)
             groups = json["groups"].select { |g| g["name"] == groups(:bern).name }
             expect(groups.size).to eq(1)
+            group = groups.first
+            expect(group.keys).to match_array(%w[id parent_id type name created_at deleted_at canton_id canton_name])
+            expect(group["canton_id"]).to eq(groups(:be).id)
           end
 
           it "does not export internes Gremium" do


### PR DESCRIPTION
Fixes https://github.com/digio-ch/pbs-healthcheck-core/issues/138
Fixes #400
Fixes #401
Refs #398

Apparently, Postgres does not consistently order rows the same way when using OFFSET vs. when not using OFFSET:

```sql
SELECT 20146 in (SELECT DISTINCT "people"."id" FROM "people" INNER JOIN [...] WHERE [...]
LIMIT 20000);
=> true
```

```sql
SELECT 20146 in (SELECT DISTINCT "people"."id" FROM "people" INNER JOIN [...] WHERE [...]
LIMIT 10000);
=> false
```

```sql
SELECT 20146 in (SELECT DISTINCT "people"."id" FROM "people" INNER JOIN [...] WHERE [...]
LIMIT 10000 OFFSET 10000);
=> false
```

The fix is to use an ORDER BY statement when using LIMIT and OFFSET:

```sql
SELECT 20146 in (SELECT DISTINCT "people"."id" FROM "people" INNER JOIN [...] WHERE [...]
ORDER BY id
LIMIT 10000 OFFSET 10000);
=> true
```

This led to pages potentially containing overlapping (duplicate) and completely missing entries. Probably has been the case since we switched to Postgres.