### PR TITLE
Bugfix: flash message respects locale

### DIFF
--- a/app/controllers/pbs/events_controller.rb
+++ b/app/controllers/pbs/events_controller.rb
@@ -13,7 +13,7 @@ module Pbs::EventsController
 
     prepend_before_action :entry, only: CrudController::ACTIONS +
       [:show_camp_application, :create_camp_application]
-    prepend_before_action :preview_camp_application_validation, only: :show
+    before_action :preview_camp_application_validation, only: :show
 
     before_render_show :load_participation_emails, if: :canceled?
     before_render_form :load_canton_specific_help_texts

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -365,6 +365,29 @@ describe EventsController do
         end
       end
     end
+
+    context "flash message respects locale" do
+      let(:event) { events(:schekka_camp) }
+
+      before {
+        event.update!(coach_id: person.id, leader_id: person.id,
+          abteilungsleitung_id: people(:al_berchtold).id)
+      }
+
+      it "failing validation" do
+        get :show, params: {group_id: event.groups.first.id, id: event.id, locale: :fr}
+        expect(flash[:warning]).to match(/Le camp ne peut pas encore être transmis par le·la coach :/)
+        expect(flash[:notice]).to be_blank
+      end
+
+      it "success message" do
+        fill_in_required_columns(event)
+
+        get :show, params: {group_id: event.groups.first.id, id: event.id, locale: :fr}
+        expect(flash[:warning]).to be_blank
+        expect(flash[:notice]).to eq "Toutes les informations nécessaires pour transmettre le camp sont disponibles."
+      end
+    end
   end
 
   context "GET show_camp_application" do


### PR DESCRIPTION
PBS meldet, dass die flash messages auf der Lager show view immer auf Deutsch angezeigt wird unabhängig von der gewählten Sprache.

<img width="1333" height="461" alt="image" src="https://github.com/user-attachments/assets/f95eb69f-6f69-4db7-a7df-f21ef439f985" />

Die Ursache ist, dass die flash message in einem `prepend_before_action` callback generiert wird:
```ruby
prepend_before_action :preview_camp_application_validation, only: :show
```

Die Locale wird in einem `around_action` gesetzt. Das `prepend_before_action` bewirkt, dass die flash messages vor dem Setzen der locale generiert werden.

Der Fix ist einfach das `prepend_before_action` durch ein simples `before_action` zu ersetzen.