### PR TITLE
Cleanup collection select calls 🤖

### DIFF
--- a/app/views/event/participation_contact_datas/_fields_pbs.html.haml
+++ b/app/views/event/participation_contact_datas/_fields_pbs.html.haml
@@ -8,7 +8,7 @@
     - if event.show_contact_attr?(:title)
       = f.labeled_input_field :title
     - if event.show_contact_attr?(:salutation)
-      = f.labeled_collection_select :salutation, Salutation.available, :first, :last, { include_blank: "" }, class: 'form-select form-select-sm'
+      = f.labeled_collection_select :salutation, Salutation.available, :first, :last, { include_blank: "" }
     - if event.show_contact_attr?(:grade_of_school)
       = f.labeled_input_field :grade_of_school, help_inline: t('people.fields_pbs.non_automatic_field')
 

--- a/app/views/people/_fields_pbs.html.haml
+++ b/app/views/people/_fields_pbs.html.haml
@@ -6,7 +6,7 @@
 = field_set_tag do
   = f.labeled_input_field :pronouns
   = f.labeled_input_field :title
-  = f.labeled_collection_select :salutation, Salutation.available, :first, :last, { include_blank: "" }, class: 'form-select form-select-sm'
+  = f.labeled_collection_select :salutation, Salutation.available, :first, :last, { include_blank: "" }
   = f.labeled_input_field :grade_of_school, help_inline: t('.non_automatic_field')
 
 = field_set_tag do


### PR DESCRIPTION
Remove now-redundant class: 'form-select form-select-sm' defaults from
collection_select/labeled_collection_select calls, now that
StandardFormBuilder#collection_select applies this class by default.
