### PR TITLE
Remove duplicate language field on profile

### DIFF
--- a/app/views/people/_details_pbs.html.haml
+++ b/app/views/people/_details_pbs.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_pbs.
 
-= render_attrs(entry, :pbs_number, :salutation, :language, :grade_of_school)
+= render_attrs(entry, :pbs_number, :salutation, :grade_of_school)
 
 %dl.dl-horizontal
   - sibling_context = parent.try(:layer_group) || parent


### PR DESCRIPTION
Currently, a profiles language field gets rendererd twice, because it is defined in the core and the PBS wagon.
This PR removes rendering of the field in the pbs wagon.